### PR TITLE
https://kyoani.cn/ 友链申请

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -106,5 +106,9 @@ friends: [
     {
         title: "《吹响！上低音号》在线播放",
         href: "https://next.hyouka.ml/"
+    },
+    {
+        title: "Kyoani.cn",
+        href: "https://kyoani.cn/"
     }
 ]


### PR DESCRIPTION
https://kyoani.cn/ 首页已添加「京吹学报」友链

这个组织下现有[「笨蛋日常整理计划」 ](https://kyoani.cn/anibaka)