### PR TITLE
Feature/dark-mode: 添加深色模式支持

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,8 @@ module.exports = function(grunt) {
                     paths: ["css"]
                 },
                 files: {
-                    "css/<%= pkg.name %>.css": "less/<%= pkg.name %>.less"
+                    "css/<%= pkg.name %>.css": "less/<%= pkg.name %>.less",
+                    "css/dark-mode.css": "less/dark-mode.less"
                 }
             },
             minified: {
@@ -24,7 +25,8 @@ module.exports = function(grunt) {
                     cleancss: true
                 },
                 files: {
-                    "css/<%= pkg.name %>.min.css": "less/<%= pkg.name %>.less"
+                    "css/<%= pkg.name %>.min.css": "less/<%= pkg.name %>.less",
+                    "css/dark-mode.min.css": "less/dark-mode.less"
                 }
             }
         },

--- a/_config.yml
+++ b/_config.yml
@@ -82,7 +82,7 @@ giscus:
   reactions-enabled: 1
   emit-metadata: 0
   input-position: bottom
-  theme: preferred_color_scheme
+  theme: auto  # light, dark, auto (跟随网站深色模式)
   lang: zh-CN
 
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -191,12 +191,22 @@
     // only load tagcloud.js in tag.html
     if($('#tag_cloud').length !== 0){
         async('{{ "/js/jquery.tagcloud.js" | prepend: site.baseurl }}',function(){
-            const isDarkMode = document.documentElement.getAttribute('data-theme') === 'dark';
-            $.fn.tagcloud.defaults = {
-                //size: {start: 1, end: 1, unit: 'em'},
-                color: isDarkMode ? {start: '#4a9eff', end: '#b8d4ff'} : {start: '#bbbbee', end: '#0085a1'},
-            };
-            $('#tag_cloud a').tagcloud();
+            // Wait for CSS to be fully applied
+            setTimeout(function() {
+                // Get CSS variables from body
+                const lightColor = getComputedStyle(document.body).getPropertyValue('--tagcloud-light-color').trim();
+                const darkColor = getComputedStyle(document.body).getPropertyValue('--tagcloud-dark-color').trim();
+                
+                // Fallback to default colors if CSS variables are not available
+                const finalLightColor = lightColor || '#bbbbee';
+                const finalDarkColor = darkColor || '#0085a1';
+                
+                $.fn.tagcloud.defaults = {
+                    //size: {start: 1, end: 1, unit: 'em'},
+                    color: {start: finalLightColor, end: finalDarkColor},
+                };
+                $('#tag_cloud a').tagcloud();
+            }, 100);
         })
     }
 </script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -191,9 +191,10 @@
     // only load tagcloud.js in tag.html
     if($('#tag_cloud').length !== 0){
         async('{{ "/js/jquery.tagcloud.js" | prepend: site.baseurl }}',function(){
+            const isDarkMode = document.documentElement.getAttribute('data-theme') === 'dark';
             $.fn.tagcloud.defaults = {
                 //size: {start: 1, end: 1, unit: 'em'},
-                color: {start: '#bbbbee', end: '#0085a1'},
+                color: isDarkMode ? {start: '#4a9eff', end: '#b8d4ff'} : {start: '#bbbbee', end: '#0085a1'},
             };
             $('#tag_cloud a').tagcloud();
         })

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,8 +28,20 @@
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ "/css/hux-blog.min.css" | prepend: site.baseurl }}">
 
+    <!-- Dark Mode CSS -->
+    <link rel="stylesheet" href="{{ "/css/dark-mode.css" | prepend: site.baseurl }}">
+
     <!-- Pygments Github CSS -->
     <link rel="stylesheet" href="{{ "/css/syntax.css" | prepend: site.baseurl }}">
+
+    <!-- Dark Mode Script (Load Early) -->
+    <script>
+        // 立即执行，避免闪烁
+        (function() {
+            const theme = localStorage.getItem('theme') || 'light';
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
 
     <!-- Custom Fonts -->
     <!-- <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css"> -->

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -34,6 +34,11 @@
                     <li>
                         <a href="/about">加入我们</a>
                     </li>
+                    <li>
+                        <a href="javascript:void(0);" id="theme-toggle" title="切换深色/浅色模式">
+                            <i class="fa fa-moon-o" id="theme-icon"></i>
+                        </a>
+                    </li>
                 </ul> 
                 <div class="navbar-nav navbar-right">
                     <form role="search" action="https://www.bing.com/search" method="get" target="_blank">
@@ -105,6 +110,34 @@
         __HuxNav__.close();
         document.getElementById('searchResults').innerHTML=''
     })
+
+    // Dark Mode Toggle
+    const themeToggle = document.getElementById('theme-toggle');
+    const themeIcon = document.getElementById('theme-icon');
+    
+    function updateThemeIcon(theme) {
+        if (theme === 'dark') {
+            themeIcon.className = 'fa fa-sun-o';
+        } else {
+            themeIcon.className = 'fa fa-moon-o';
+        }
+    }
+    
+    // 初始化图标
+    const currentTheme = localStorage.getItem('theme') || 'light';
+    updateThemeIcon(currentTheme);
+    
+    themeToggle.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        
+        const currentTheme = document.documentElement.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        
+        document.documentElement.setAttribute('data-theme', newTheme);
+        localStorage.setItem('theme', newTheme);
+        updateThemeIcon(newTheme);
+    });
 </script>
 
 <style>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -138,11 +138,18 @@
         localStorage.setItem('theme', newTheme);
         updateThemeIcon(newTheme);
         
-        // Reinitialize tagcloud with new theme colors
+        // Reinitialize tagcloud with new theme colors from CSS variables
         if($('#tag_cloud').length !== 0 && typeof $.fn.tagcloud !== 'undefined') {
-            const isDarkMode = newTheme === 'dark';
+            // Get CSS variables from body
+            const lightColor = getComputedStyle(document.body).getPropertyValue('--tagcloud-light-color').trim();
+            const darkColor = getComputedStyle(document.body).getPropertyValue('--tagcloud-dark-color').trim();
+            
+            // Fallback to default colors if CSS variables are not available
+            const finalLightColor = lightColor || '#bbbbee';
+            const finalDarkColor = darkColor || '#0085a1';
+            
             $.fn.tagcloud.defaults = {
-                color: isDarkMode ? {start: '#4a9eff', end: '#b8d4ff'} : {start: '#bbbbee', end: '#0085a1'},
+                color: {start: finalLightColor, end: finalDarkColor},
             };
             // Remove inline styles and reinitialize
             $('#tag_cloud a').removeAttr('style').tagcloud();

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -137,6 +137,16 @@
         document.documentElement.setAttribute('data-theme', newTheme);
         localStorage.setItem('theme', newTheme);
         updateThemeIcon(newTheme);
+        
+        // Reinitialize tagcloud with new theme colors
+        if($('#tag_cloud').length !== 0 && typeof $.fn.tagcloud !== 'undefined') {
+            const isDarkMode = newTheme === 'dark';
+            $.fn.tagcloud.defaults = {
+                color: isDarkMode ? {start: '#4a9eff', end: '#b8d4ff'} : {start: '#bbbbee', end: '#0085a1'},
+            };
+            // Remove inline styles and reinitialize
+            $('#tag_cloud a').removeAttr('style').tagcloud();
+        }
     });
 </script>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -120,11 +120,40 @@ layout: default
                         data-reactions-enabled="{{ site.giscus.reactions-enabled }}"
                         data-emit-metadata="{{ site.giscus.emit-metadata }}"
                         data-input-position="{{ site.giscus.input-position }}"
-                        data-theme="{{ site.giscus.theme }}"
+                        data-theme="{% if site.giscus.theme == 'auto' %}light{% else %}{{ site.giscus.theme }}{% endif %}"
                         data-lang="{{ site.giscus.lang }}"
                         crossorigin="anonymous"
-                        async>
+                        async
+                        id="giscus-script">
                 </script>
+                {% if site.giscus.theme == 'auto' %}
+                <script>
+                    // 监听深色模式变化，动态更新 Giscus 主题
+                    function updateGiscusTheme() {
+                        const theme = document.documentElement.getAttribute('data-theme') || 'light';
+                        const giscusTheme = theme === 'dark' ? 'dark' : 'light';
+                        
+                        // 发送消息给 Giscus iframe 更新主题
+                        const giscusIframe = document.querySelector('iframe.giscus-frame');
+                        if (giscusIframe) {
+                            giscusIframe.contentWindow.postMessage(
+                                { giscus: { setConfig: { theme: giscusTheme } } },
+                                'https://giscus.app'
+                            );
+                        }
+                    }
+                    
+                    // 初始化时更新主题
+                    window.addEventListener('load', updateGiscusTheme);
+                    
+                    // 监听主题切换事件
+                    const observer = new MutationObserver(updateGiscusTheme);
+                    observer.observe(document.documentElement, {
+                        attributes: true,
+                        attributeFilter: ['data-theme']
+                    });
+                </script>
+                {% endif %}
                 {% endif %}
                 <!-- Giscus end -->
 

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -130,7 +130,9 @@
   text-decoration: none;
 }
 [data-theme="dark"] .post-preview > a:hover > .post-title,
-[data-theme="dark"] .post-preview > a:focus > .post-title {
+[data-theme="dark"] .post-preview > a:focus > .post-title,
+[data-theme="dark"] .post-preview > a:hover > .post-subtitle,
+[data-theme="dark"] .post-preview > a:focus > .post-subtitle {
   color: #6eb5ff;
 }
 [data-theme="dark"] .post-preview > .post-meta {
@@ -166,8 +168,7 @@
 }
 [data-theme="dark"] .side-catalog {
   background-color: #1a1a1a;
-  border: 1px solid #404040;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  box-shadow: none;
 }
 [data-theme="dark"] .side-catalog h5 a {
   color: #e0e0e0;
@@ -267,19 +268,6 @@
 [data-theme="dark"] footer .copyright a:focus {
   color: #9fd3ff;
 }
-[data-theme="dark"] #gitalk-container .gt-container .gt-header-textarea {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #404040;
-}
-[data-theme="dark"] #gitalk-container .gt-container .gt-comment {
-  background-color: #2d2d2d;
-  border-color: #404040;
-}
-[data-theme="dark"] #gitalk-container .gt-container .gt-comment .gt-comment-content {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-}
 [data-theme="dark"] input,
 [data-theme="dark"] textarea,
 [data-theme="dark"] select {
@@ -292,6 +280,19 @@
 [data-theme="dark"] select:focus {
   background-color: #2d2d2d;
   border-color: #6eb5ff;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-header-textarea {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #404040;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-comment {
+  background-color: #2d2d2d;
+  border-color: #404040;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-comment .gt-comment-content {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
 }
 [data-theme="dark"] #search-bar {
   background-color: #2d2d2d !important;

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -209,6 +209,32 @@
   border-color: #a78bfa;
   color: white !important;
 }
+[data-theme="dark"] .post-heading .tags a,
+[data-theme="dark"] .page-heading .tags a,
+[data-theme="dark"] .site-heading .tags a,
+[data-theme="dark"] .post-heading .tags .tag,
+[data-theme="dark"] .page-heading .tags .tag,
+[data-theme="dark"] .site-heading .tags .tag {
+  background-color: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.9);
+}
+[data-theme="dark"] .post-heading .tags a:hover,
+[data-theme="dark"] .page-heading .tags a:hover,
+[data-theme="dark"] .site-heading .tags a:hover,
+[data-theme="dark"] .post-heading .tags .tag:hover,
+[data-theme="dark"] .page-heading .tags .tag:hover,
+[data-theme="dark"] .site-heading .tags .tag:hover,
+[data-theme="dark"] .post-heading .tags a:active,
+[data-theme="dark"] .page-heading .tags a:active,
+[data-theme="dark"] .site-heading .tags a:active,
+[data-theme="dark"] .post-heading .tags .tag:active,
+[data-theme="dark"] .page-heading .tags .tag:active,
+[data-theme="dark"] .site-heading .tags .tag:active {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.6);
+  color: white !important;
+}
 [data-theme="dark"] hr,
 [data-theme="dark"] hr.small {
   border-color: #3d2d5d;

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -134,7 +134,9 @@
   text-decoration: none;
 }
 [data-theme="dark"] .post-preview > a:hover > .post-title,
-[data-theme="dark"] .post-preview > a:focus > .post-title {
+[data-theme="dark"] .post-preview > a:focus > .post-title,
+[data-theme="dark"] .post-preview > a:hover > .post-subtitle,
+[data-theme="dark"] .post-preview > a:focus > .post-subtitle {
   color: #a78bfa;
 }
 [data-theme="dark"] .post-preview > .post-meta {

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -185,7 +185,7 @@
   color: #c4b5fd;
 }
 [data-theme="dark"] .side-catalog .catalog-body li.active {
-  background-color: #2d1b4e;
+  background-color: #3d2d5d;
   border-radius: 4px;
 }
 [data-theme="dark"] .tags a,

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -127,6 +127,11 @@
 [data-theme="dark"] .post-preview > a:hover,
 [data-theme="dark"] .post-preview > a:focus {
   color: #6eb5ff;
+  text-decoration: none;
+}
+[data-theme="dark"] .post-preview > a:hover > .post-title,
+[data-theme="dark"] .post-preview > a:focus > .post-title {
+  color: #6eb5ff;
 }
 [data-theme="dark"] .post-preview > .post-meta {
   color: #b0b0b0;
@@ -243,8 +248,9 @@
 [data-theme="dark"] .pager .disabled > a:hover,
 [data-theme="dark"] .pager .disabled > a:focus,
 [data-theme="dark"] .pager .disabled > span {
-  background-color: #3a3a3a;
-  color: #666;
+  color: #404040;
+  background-color: #1a1a1a;
+  cursor: not-allowed;
 }
 [data-theme="dark"] footer {
   background-color: #2d2d2d;

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -175,15 +175,12 @@
 }
 [data-theme="dark"] .side-catalog .catalog-body li a {
   color: #b0b0b0;
-  border-left: 2px solid #404040;
 }
 [data-theme="dark"] .side-catalog .catalog-body li a:hover {
   color: #6eb5ff;
-  border-left-color: #6eb5ff;
 }
 [data-theme="dark"] .side-catalog .catalog-body li a.active {
   color: #6eb5ff;
-  border-left-color: #6eb5ff;
 }
 [data-theme="dark"] .tags a,
 [data-theme="dark"] .tags .tag {
@@ -197,7 +194,7 @@
 [data-theme="dark"] .tags .tag:active {
   background-color: #6eb5ff;
   border-color: #6eb5ff;
-  color: white;
+  color: white !important;
 }
 [data-theme="dark"] hr,
 [data-theme="dark"] hr.small {
@@ -212,14 +209,14 @@
 [data-theme="dark"] #tag_cloud a,
 [data-theme="dark"] #tag_cloud .tag {
   color: #e0e0e0 !important;
-  border: 1px solid #404040 !important;
+  border: none !important;
 }
 [data-theme="dark"] #tag_cloud a:hover,
 [data-theme="dark"] #tag_cloud .tag:hover,
 [data-theme="dark"] #tag_cloud a:active,
 [data-theme="dark"] #tag_cloud .tag:active {
   color: white !important;
-  border-color: #6eb5ff !important;
+  border: none !important;
 }
 [data-theme="dark"] .pager li > a,
 [data-theme="dark"] .pager li > span {
@@ -245,9 +242,10 @@
 [data-theme="dark"] .pager .disabled > a:hover,
 [data-theme="dark"] .pager .disabled > a:focus,
 [data-theme="dark"] .pager .disabled > span {
-  color: #404040;
-  background-color: #1a1a1a;
-  cursor: not-allowed;
+  color: #808080 !important;
+  background-color: #1f1f1f !important;
+  cursor: not-allowed !important;
+  pointer-events: none !important;
 }
 [data-theme="dark"] footer {
   background-color: #2d2d2d;
@@ -301,6 +299,9 @@
   border-color: #6eb5ff !important;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
 }
+[data-theme="dark"] #search-bar:not(:focus) {
+  color: #e0e0e0 !important;
+}
 [data-theme="dark"] .form-control {
   background-color: #2d2d2d;
   color: #e0e0e0;
@@ -333,18 +334,4 @@
 [data-theme="dark"] ::-moz-selection {
   background: #6eb5ff;
   color: white;
-}
-[data-theme="dark"] ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-[data-theme="dark"] ::-webkit-scrollbar-track {
-  background: #1a1a1a;
-}
-[data-theme="dark"] ::-webkit-scrollbar-thumb {
-  background: #2d2d2d;
-  border-radius: 5px;
-}
-[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
-  background: #4a4a4a;
 }

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -1,6 +1,9 @@
 [data-theme="dark"] body {
-  background-color: #1a1a1a;
-  color: #e0e0e0;
+  background-color: #1a0f2e;
+  color: #e8dff5;
+  --tagcloud-light-color: #b8a8d8;
+  --tagcloud-dark-color: #7a5fa8;
+  --accent-color: #c4b5fd;
 }
 [data-theme="dark"] h1,
 [data-theme="dark"] h2,
@@ -8,40 +11,40 @@
 [data-theme="dark"] h4,
 [data-theme="dark"] h5,
 [data-theme="dark"] h6 {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] a {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] a:hover,
 [data-theme="dark"] a:focus {
-  color: #9fd3ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] .navbar-custom {
-  background-color: rgba(45, 45, 45, 0.95);
-  border-bottom: 1px solid #404040;
+  background-color: rgba(45, 27, 78, 0.95);
+  border-bottom: 1px solid #3d2d5d;
 }
 [data-theme="dark"] .navbar-custom.is-fixed {
-  background-color: rgba(45, 45, 45, 0.95);
-  border-bottom: 1px solid #404040;
+  background-color: rgba(45, 27, 78, 0.95);
+  border-bottom: 1px solid #3d2d5d;
 }
 [data-theme="dark"] .navbar-custom.is-fixed .navbar-brand {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .navbar-custom.is-fixed .navbar-brand:hover,
 [data-theme="dark"] .navbar-custom.is-fixed .navbar-brand:focus {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .navbar-custom.is-fixed .nav li a {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .navbar-custom.is-fixed .nav li a:hover,
 [data-theme="dark"] .navbar-custom.is-fixed .nav li a:focus {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 @media only screen and (max-width: 767px) {
   [data-theme="dark"] .navbar-default .navbar-collapse {
-    background: #2d2d2d;
+    background: #2d1b4e;
     box-shadow: 0px 5px 10px 2px rgba(0, 0, 0, 0.5);
   }
 }
@@ -61,40 +64,40 @@
 }
 [data-theme="dark"] .post-container,
 [data-theme="dark"] .postlist-container {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .post-container a,
 [data-theme="dark"] .postlist-container a {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .post-container a:hover,
 [data-theme="dark"] .postlist-container a:hover,
 [data-theme="dark"] .post-container a:focus,
 [data-theme="dark"] .postlist-container a:focus {
-  color: #9fd3ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] .post-container h5,
 [data-theme="dark"] .postlist-container h5,
 [data-theme="dark"] .post-container h6,
 [data-theme="dark"] .postlist-container h6 {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-container blockquote,
 [data-theme="dark"] .postlist-container blockquote {
-  background-color: #252525;
-  border-left: 4px solid #404040;
-  color: #b0b0b0;
+  background-color: #251a42;
+  border-left: 4px solid #3d2d5d;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-container code,
 [data-theme="dark"] .postlist-container code {
-  background-color: #2d2d2d;
+  background-color: #2d1b4e;
   color: #ff6b6b;
-  border: 1px solid #404040;
+  border: 1px solid #3d2d5d;
 }
 [data-theme="dark"] .post-container pre,
 [data-theme="dark"] .postlist-container pre {
-  background-color: #2d2d2d;
-  border: 1px solid #404040;
+  background-color: #2d1b4e;
+  border: 1px solid #3d2d5d;
 }
 [data-theme="dark"] .post-container pre code,
 [data-theme="dark"] .postlist-container pre code {
@@ -105,8 +108,8 @@
 [data-theme="dark"] .postlist-container table th,
 [data-theme="dark"] .post-container table td,
 [data-theme="dark"] .postlist-container table td {
-  border: 1px solid #404040 !important;
-  background-color: #2d2d2d;
+  border: 1px solid #3d2d5d !important;
+  background-color: #2d1b4e;
 }
 [data-theme="dark"] .post-container table thead th,
 [data-theme="dark"] .postlist-container table thead th {
@@ -122,93 +125,96 @@
   opacity: 1;
 }
 [data-theme="dark"] .post-preview > a {
-  color: #e0e0e0;
+  color: #e8dff5;
+  transition: all 0.4s ease;
 }
 [data-theme="dark"] .post-preview > a:hover,
 [data-theme="dark"] .post-preview > a:focus {
-  color: #6eb5ff;
+  color: #a78bfa;
   text-decoration: none;
 }
 [data-theme="dark"] .post-preview > a:hover > .post-title,
-[data-theme="dark"] .post-preview > a:focus > .post-title,
-[data-theme="dark"] .post-preview > a:hover > .post-subtitle,
-[data-theme="dark"] .post-preview > a:focus > .post-subtitle {
-  color: #6eb5ff;
+[data-theme="dark"] .post-preview > a:focus > .post-title {
+  color: #a78bfa;
 }
 [data-theme="dark"] .post-preview > .post-meta {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-preview > .post-meta > a {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-preview > .post-meta > a:hover,
 [data-theme="dark"] .post-preview > .post-meta > a:focus {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .post-content-preview {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-content-preview:hover {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .sidebar-container {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .sidebar-container h5 {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .sidebar-container h5 a {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .sidebar-container h5 a:hover {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .sidebar-container .short-about {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .side-catalog {
-  background-color: #1a1a1a;
+  background-color: #1a0f2e;
   box-shadow: none;
 }
 [data-theme="dark"] .side-catalog h5 a {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .side-catalog .catalog-body li a {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .side-catalog .catalog-body li a:hover {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .side-catalog .catalog-body li a.active {
-  color: #6eb5ff;
+  color: #c4b5fd;
+}
+[data-theme="dark"] .side-catalog .catalog-body li.active {
+  background-color: #2d1b4e;
+  border-radius: 4px;
 }
 [data-theme="dark"] .tags a,
 [data-theme="dark"] .tags .tag {
-  background-color: #2d2d2d;
-  border-color: #404040;
-  color: #e0e0e0;
+  background-color: #2d1b4e;
+  border-color: #3d2d5d;
+  color: #e8dff5;
 }
 [data-theme="dark"] .tags a:hover,
 [data-theme="dark"] .tags .tag:hover,
 [data-theme="dark"] .tags a:active,
 [data-theme="dark"] .tags .tag:active {
-  background-color: #6eb5ff;
-  border-color: #6eb5ff;
+  background-color: #a78bfa;
+  border-color: #a78bfa;
   color: white !important;
 }
 [data-theme="dark"] hr,
 [data-theme="dark"] hr.small {
-  border-color: #404040;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] .listing-seperator {
-  color: #6eb5ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] .listing-seperator:hover {
-  color: #9fd3ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] #tag_cloud a,
 [data-theme="dark"] #tag_cloud .tag {
-  color: #e0e0e0 !important;
+  color: #e8dff5 !important;
   border: none !important;
 }
 [data-theme="dark"] #tag_cloud a:hover,
@@ -220,18 +226,18 @@
 }
 [data-theme="dark"] .pager li > a,
 [data-theme="dark"] .pager li > span {
-  background-color: #2d2d2d;
-  border: 1px solid #404040;
-  color: #e0e0e0;
+  background-color: #2d1b4e;
+  border: 1px solid #3d2d5d;
+  color: #e8dff5;
 }
 [data-theme="dark"] .pager li > a span,
 [data-theme="dark"] .pager li > span span {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .pager li > a:hover,
 [data-theme="dark"] .pager li > a:focus {
-  background-color: #6eb5ff;
-  border-color: #6eb5ff;
+  background-color: #a78bfa;
+  border-color: #a78bfa;
   color: white;
 }
 [data-theme="dark"] .pager li > a:hover span,
@@ -242,96 +248,97 @@
 [data-theme="dark"] .pager .disabled > a:hover,
 [data-theme="dark"] .pager .disabled > a:focus,
 [data-theme="dark"] .pager .disabled > span {
-  color: #808080 !important;
-  background-color: #1f1f1f !important;
+  color: #8b7ba8 !important;
+  background-color: #1f1535 !important;
+  border-color: #3d2d5d !important;
   cursor: not-allowed !important;
   pointer-events: none !important;
 }
 [data-theme="dark"] footer {
-  background-color: #2d2d2d;
-  border-top: 1px solid #404040;
-  color: #b0b0b0;
+  background-color: #2d1b4e;
+  border-top: 1px solid #3d2d5d;
+  color: #b8a8d8;
 }
 [data-theme="dark"] footer .copyright {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] footer .copyright a {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] footer .copyright a:hover,
 [data-theme="dark"] footer .copyright a:focus {
-  color: #9fd3ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] input,
 [data-theme="dark"] textarea,
 [data-theme="dark"] select {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #404040;
+  background-color: #2d1b4e;
+  color: #e8dff5;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] input:focus,
 [data-theme="dark"] textarea:focus,
 [data-theme="dark"] select:focus {
-  background-color: #2d2d2d;
-  border-color: #6eb5ff;
+  background-color: #2d1b4e;
+  border-color: #a78bfa;
 }
 [data-theme="dark"] #gitalk-container .gt-container .gt-header-textarea {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #404040;
+  background-color: #2d1b4e;
+  color: #e8dff5;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] #gitalk-container .gt-container .gt-comment {
-  background-color: #2d2d2d;
-  border-color: #404040;
+  background-color: #2d1b4e;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] #gitalk-container .gt-container .gt-comment .gt-comment-content {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
+  background-color: #2d1b4e;
+  color: #e8dff5;
 }
 [data-theme="dark"] #search-bar {
-  background-color: #2d2d2d !important;
-  color: #e0e0e0 !important;
-  border-color: #404040 !important;
+  background-color: #2d1b4e !important;
+  color: #e8dff5 !important;
+  border-color: #3d2d5d !important;
 }
 [data-theme="dark"] #search-bar:focus {
-  background-color: #2d2d2d !important;
-  color: #e0e0e0 !important;
-  border-color: #6eb5ff !important;
+  background-color: #2d1b4e !important;
+  color: #e8dff5 !important;
+  border-color: #a78bfa !important;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
 }
 [data-theme="dark"] #search-bar:not(:focus) {
-  color: #e0e0e0 !important;
+  color: #e8dff5 !important;
 }
 [data-theme="dark"] .form-control {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #404040;
+  background-color: #2d1b4e;
+  color: #e8dff5;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] .form-control:focus {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #6eb5ff;
+  background-color: #2d1b4e;
+  color: #e8dff5;
+  border-color: #a78bfa;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6);
 }
 [data-theme="dark"] .form-control::placeholder {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .btn-default {
-  background-color: #2d2d2d;
-  border-color: #404040;
-  color: #e0e0e0;
+  background-color: #2d1b4e;
+  border-color: #3d2d5d;
+  color: #e8dff5;
 }
 [data-theme="dark"] .btn-default:hover,
 [data-theme="dark"] .btn-default:focus {
-  background-color: #6eb5ff;
-  border-color: #6eb5ff;
+  background-color: #a78bfa;
+  border-color: #a78bfa;
   color: white;
 }
 [data-theme="dark"] ::selection {
-  background: #6eb5ff;
+  background: #a78bfa;
   color: white;
 }
 [data-theme="dark"] ::-moz-selection {
-  background: #6eb5ff;
+  background: #a78bfa;
   color: white;
 }

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -15,6 +15,12 @@
 }
 [data-theme="dark"] a {
   color: #a78bfa;
+  transition: all 0.4s ease;
+  -moz-transition: all 0.4s ease;
+  /* Firefox 4 */
+  -webkit-transition: all 0.4s ease;
+  /* Safari 和 Chrome */
+  -o-transition: all 0.4s ease;
 }
 [data-theme="dark"] a:hover,
 [data-theme="dark"] a:focus {
@@ -126,7 +132,6 @@
 }
 [data-theme="dark"] .post-preview > a {
   color: #e8dff5;
-  transition: all 0.4s ease;
 }
 [data-theme="dark"] .post-preview > a:hover,
 [data-theme="dark"] .post-preview > a:focus {

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -211,8 +211,6 @@
 }
 [data-theme="dark"] #tag_cloud a,
 [data-theme="dark"] #tag_cloud .tag {
-  background-color: #2d2d2d !important;
-  background: #2d2d2d !important;
   color: #e0e0e0 !important;
   border: 1px solid #404040 !important;
 }
@@ -220,8 +218,6 @@
 [data-theme="dark"] #tag_cloud .tag:hover,
 [data-theme="dark"] #tag_cloud a:active,
 [data-theme="dark"] #tag_cloud .tag:active {
-  background-color: #6eb5ff !important;
-  background: #6eb5ff !important;
   color: white !important;
   border-color: #6eb5ff !important;
 }

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -1,0 +1,347 @@
+[data-theme="dark"] body {
+  background-color: #1a1a1a;
+  color: #e0e0e0;
+}
+[data-theme="dark"] h1,
+[data-theme="dark"] h2,
+[data-theme="dark"] h3,
+[data-theme="dark"] h4,
+[data-theme="dark"] h5,
+[data-theme="dark"] h6 {
+  color: #e0e0e0;
+}
+[data-theme="dark"] a {
+  color: #6eb5ff;
+}
+[data-theme="dark"] a:hover,
+[data-theme="dark"] a:focus {
+  color: #9fd3ff;
+}
+[data-theme="dark"] .navbar-custom {
+  background-color: rgba(45, 45, 45, 0.95);
+  border-bottom: 1px solid #404040;
+}
+[data-theme="dark"] .navbar-custom.is-fixed {
+  background-color: rgba(45, 45, 45, 0.95);
+  border-bottom: 1px solid #404040;
+}
+[data-theme="dark"] .navbar-custom.is-fixed .navbar-brand {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .navbar-custom.is-fixed .navbar-brand:hover,
+[data-theme="dark"] .navbar-custom.is-fixed .navbar-brand:focus {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .navbar-custom.is-fixed .nav li a {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .navbar-custom.is-fixed .nav li a:hover,
+[data-theme="dark"] .navbar-custom.is-fixed .nav li a:focus {
+  color: #6eb5ff;
+}
+@media only screen and (max-width: 767px) {
+  [data-theme="dark"] .navbar-default .navbar-collapse {
+    background: #2d2d2d;
+    box-shadow: 0px 5px 10px 2px rgba(0, 0, 0, 0.5);
+  }
+}
+[data-theme="dark"] .intro-header .post-heading h1,
+[data-theme="dark"] .intro-header .page-heading h1,
+[data-theme="dark"] .intro-header .site-heading h1,
+[data-theme="dark"] .intro-header .post-heading h2,
+[data-theme="dark"] .intro-header .page-heading h2,
+[data-theme="dark"] .intro-header .site-heading h2,
+[data-theme="dark"] .intro-header .post-heading .subheading,
+[data-theme="dark"] .intro-header .page-heading .subheading,
+[data-theme="dark"] .intro-header .site-heading .subheading,
+[data-theme="dark"] .intro-header .post-heading .meta,
+[data-theme="dark"] .intro-header .page-heading .meta,
+[data-theme="dark"] .intro-header .site-heading .meta {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+[data-theme="dark"] .post-container,
+[data-theme="dark"] .postlist-container {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .post-container a,
+[data-theme="dark"] .postlist-container a {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .post-container a:hover,
+[data-theme="dark"] .postlist-container a:hover,
+[data-theme="dark"] .post-container a:focus,
+[data-theme="dark"] .postlist-container a:focus {
+  color: #9fd3ff;
+}
+[data-theme="dark"] .post-container h5,
+[data-theme="dark"] .postlist-container h5,
+[data-theme="dark"] .post-container h6,
+[data-theme="dark"] .postlist-container h6 {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-container blockquote,
+[data-theme="dark"] .postlist-container blockquote {
+  background-color: #252525;
+  border-left: 4px solid #404040;
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-container code,
+[data-theme="dark"] .postlist-container code {
+  background-color: #2d2d2d;
+  color: #ff6b6b;
+  border: 1px solid #404040;
+}
+[data-theme="dark"] .post-container pre,
+[data-theme="dark"] .postlist-container pre {
+  background-color: #2d2d2d;
+  border: 1px solid #404040;
+}
+[data-theme="dark"] .post-container pre code,
+[data-theme="dark"] .postlist-container pre code {
+  background-color: transparent;
+  border: none;
+}
+[data-theme="dark"] .post-container table th,
+[data-theme="dark"] .postlist-container table th,
+[data-theme="dark"] .post-container table td,
+[data-theme="dark"] .postlist-container table td {
+  border: 1px solid #404040 !important;
+  background-color: #2d2d2d;
+}
+[data-theme="dark"] .post-container table thead th,
+[data-theme="dark"] .postlist-container table thead th {
+  background-color: #3a3a3a;
+}
+[data-theme="dark"] .post-container img,
+[data-theme="dark"] .postlist-container img {
+  opacity: 0.9;
+  transition: opacity 0.3s ease;
+}
+[data-theme="dark"] .post-container img:hover,
+[data-theme="dark"] .postlist-container img:hover {
+  opacity: 1;
+}
+[data-theme="dark"] .post-preview > a {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .post-preview > a:hover,
+[data-theme="dark"] .post-preview > a:focus {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .post-preview > .post-meta {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-preview > .post-meta > a {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-preview > .post-meta > a:hover,
+[data-theme="dark"] .post-preview > .post-meta > a:focus {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .post-content-preview {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-content-preview:hover {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .sidebar-container {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .sidebar-container h5 {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .sidebar-container h5 a {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .sidebar-container h5 a:hover {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .sidebar-container .short-about {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .side-catalog {
+  background-color: #1a1a1a;
+  border: 1px solid #404040;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+[data-theme="dark"] .side-catalog h5 a {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .side-catalog .catalog-body li a {
+  color: #b0b0b0;
+  border-left: 2px solid #404040;
+}
+[data-theme="dark"] .side-catalog .catalog-body li a:hover {
+  color: #6eb5ff;
+  border-left-color: #6eb5ff;
+}
+[data-theme="dark"] .side-catalog .catalog-body li a.active {
+  color: #6eb5ff;
+  border-left-color: #6eb5ff;
+}
+[data-theme="dark"] .tags a,
+[data-theme="dark"] .tags .tag {
+  background-color: #2d2d2d;
+  border-color: #404040;
+  color: #e0e0e0;
+}
+[data-theme="dark"] .tags a:hover,
+[data-theme="dark"] .tags .tag:hover,
+[data-theme="dark"] .tags a:active,
+[data-theme="dark"] .tags .tag:active {
+  background-color: #6eb5ff;
+  border-color: #6eb5ff;
+  color: white;
+}
+[data-theme="dark"] hr,
+[data-theme="dark"] hr.small {
+  border-color: #404040;
+}
+[data-theme="dark"] .listing-seperator {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .listing-seperator:hover {
+  color: #9fd3ff;
+}
+[data-theme="dark"] #tag_cloud a,
+[data-theme="dark"] #tag_cloud .tag {
+  background-color: #2d2d2d !important;
+  background: #2d2d2d !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #404040 !important;
+}
+[data-theme="dark"] #tag_cloud a:hover,
+[data-theme="dark"] #tag_cloud .tag:hover,
+[data-theme="dark"] #tag_cloud a:active,
+[data-theme="dark"] #tag_cloud .tag:active {
+  background-color: #6eb5ff !important;
+  background: #6eb5ff !important;
+  color: white !important;
+  border-color: #6eb5ff !important;
+}
+[data-theme="dark"] .pager li > a,
+[data-theme="dark"] .pager li > span {
+  background-color: #2d2d2d;
+  border: 1px solid #404040;
+  color: #e0e0e0;
+}
+[data-theme="dark"] .pager li > a span,
+[data-theme="dark"] .pager li > span span {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .pager li > a:hover,
+[data-theme="dark"] .pager li > a:focus {
+  background-color: #6eb5ff;
+  border-color: #6eb5ff;
+  color: white;
+}
+[data-theme="dark"] .pager li > a:hover span,
+[data-theme="dark"] .pager li > a:focus span {
+  color: white;
+}
+[data-theme="dark"] .pager .disabled > a,
+[data-theme="dark"] .pager .disabled > a:hover,
+[data-theme="dark"] .pager .disabled > a:focus,
+[data-theme="dark"] .pager .disabled > span {
+  background-color: #3a3a3a;
+  color: #666;
+}
+[data-theme="dark"] footer {
+  background-color: #2d2d2d;
+  border-top: 1px solid #404040;
+  color: #b0b0b0;
+}
+[data-theme="dark"] footer .copyright {
+  color: #b0b0b0;
+}
+[data-theme="dark"] footer .copyright a {
+  color: #6eb5ff;
+}
+[data-theme="dark"] footer .copyright a:hover,
+[data-theme="dark"] footer .copyright a:focus {
+  color: #9fd3ff;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-header-textarea {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #404040;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-comment {
+  background-color: #2d2d2d;
+  border-color: #404040;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-comment .gt-comment-content {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+}
+[data-theme="dark"] input,
+[data-theme="dark"] textarea,
+[data-theme="dark"] select {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #404040;
+}
+[data-theme="dark"] input:focus,
+[data-theme="dark"] textarea:focus,
+[data-theme="dark"] select:focus {
+  background-color: #2d2d2d;
+  border-color: #6eb5ff;
+}
+[data-theme="dark"] #search-bar {
+  background-color: #2d2d2d !important;
+  color: #e0e0e0 !important;
+  border-color: #404040 !important;
+}
+[data-theme="dark"] #search-bar:focus {
+  background-color: #2d2d2d !important;
+  color: #e0e0e0 !important;
+  border-color: #6eb5ff !important;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
+}
+[data-theme="dark"] .form-control {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #404040;
+}
+[data-theme="dark"] .form-control:focus {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #6eb5ff;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6);
+}
+[data-theme="dark"] .form-control::placeholder {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .btn-default {
+  background-color: #2d2d2d;
+  border-color: #404040;
+  color: #e0e0e0;
+}
+[data-theme="dark"] .btn-default:hover,
+[data-theme="dark"] .btn-default:focus {
+  background-color: #6eb5ff;
+  border-color: #6eb5ff;
+  color: white;
+}
+[data-theme="dark"] ::selection {
+  background: #6eb5ff;
+  color: white;
+}
+[data-theme="dark"] ::-moz-selection {
+  background: #6eb5ff;
+  color: white;
+}
+[data-theme="dark"] ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+[data-theme="dark"] ::-webkit-scrollbar-track {
+  background: #1a1a1a;
+}
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
+  background: #2d2d2d;
+  border-radius: 5px;
+}
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+  background: #4a4a4a;
+}

--- a/css/hux-blog.css
+++ b/css/hux-blog.css
@@ -373,9 +373,10 @@
 [data-theme="dark"] .pager .disabled > a:hover,
 [data-theme="dark"] .pager .disabled > a:focus,
 [data-theme="dark"] .pager .disabled > span {
-  color: #b0b0b0 !important;
-  background-color: #2d2d2d !important;
-  cursor: not-allowed;
+  color: #808080 !important;
+  background-color: #1f1f1f !important;
+  cursor: not-allowed !important;
+  pointer-events: none !important;
 }
 [data-theme="dark"] footer {
   background-color: #2d2d2d;
@@ -1139,7 +1140,7 @@ form .row:first-child .floating-label-form-group {
 .pager .disabled > a:focus,
 .pager .disabled > span {
   color: #808080;
-  background-color: #404040;
+  background-color: #ccd0d3;
   cursor: not-allowed;
   pointer-events: none;
 }

--- a/css/hux-blog.css
+++ b/css/hux-blog.css
@@ -129,11 +129,343 @@
     display: none;
   }
 }
+[data-theme="dark"] body {
+  background-color: #1a1a1a;
+  color: #e0e0e0;
+}
+[data-theme="dark"] h1,
+[data-theme="dark"] h2,
+[data-theme="dark"] h3,
+[data-theme="dark"] h4,
+[data-theme="dark"] h5,
+[data-theme="dark"] h6 {
+  color: #e0e0e0;
+}
+[data-theme="dark"] a {
+  color: #6eb5ff;
+}
+[data-theme="dark"] a:hover,
+[data-theme="dark"] a:focus {
+  color: #9fd3ff;
+}
+[data-theme="dark"] .navbar-custom {
+  background-color: rgba(45, 45, 45, 0.95);
+  border-bottom: 1px solid #404040;
+}
+[data-theme="dark"] .navbar-custom.is-fixed {
+  background-color: rgba(45, 45, 45, 0.95);
+  border-bottom: 1px solid #404040;
+}
+[data-theme="dark"] .navbar-custom.is-fixed .navbar-brand {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .navbar-custom.is-fixed .navbar-brand:hover,
+[data-theme="dark"] .navbar-custom.is-fixed .navbar-brand:focus {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .navbar-custom.is-fixed .nav li a {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .navbar-custom.is-fixed .nav li a:hover,
+[data-theme="dark"] .navbar-custom.is-fixed .nav li a:focus {
+  color: #6eb5ff;
+}
+@media only screen and (max-width: 767px) {
+  [data-theme="dark"] .navbar-default .navbar-collapse {
+    background: #2d2d2d;
+    box-shadow: 0px 5px 10px 2px rgba(0, 0, 0, 0.5);
+  }
+}
+[data-theme="dark"] .intro-header .post-heading h1,
+[data-theme="dark"] .intro-header .page-heading h1,
+[data-theme="dark"] .intro-header .site-heading h1,
+[data-theme="dark"] .intro-header .post-heading h2,
+[data-theme="dark"] .intro-header .page-heading h2,
+[data-theme="dark"] .intro-header .site-heading h2,
+[data-theme="dark"] .intro-header .post-heading .subheading,
+[data-theme="dark"] .intro-header .page-heading .subheading,
+[data-theme="dark"] .intro-header .site-heading .subheading,
+[data-theme="dark"] .intro-header .post-heading .meta,
+[data-theme="dark"] .intro-header .page-heading .meta,
+[data-theme="dark"] .intro-header .site-heading .meta {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+[data-theme="dark"] .post-container,
+[data-theme="dark"] .postlist-container {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .post-container a,
+[data-theme="dark"] .postlist-container a {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .post-container a:hover,
+[data-theme="dark"] .postlist-container a:hover,
+[data-theme="dark"] .post-container a:focus,
+[data-theme="dark"] .postlist-container a:focus {
+  color: #9fd3ff;
+}
+[data-theme="dark"] .post-container h5,
+[data-theme="dark"] .postlist-container h5,
+[data-theme="dark"] .post-container h6,
+[data-theme="dark"] .postlist-container h6 {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-container blockquote,
+[data-theme="dark"] .postlist-container blockquote {
+  background-color: #252525;
+  border-left: 4px solid #404040;
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-container code,
+[data-theme="dark"] .postlist-container code {
+  background-color: #2d2d2d;
+  color: #ff6b6b;
+  border: 1px solid #404040;
+}
+[data-theme="dark"] .post-container pre,
+[data-theme="dark"] .postlist-container pre {
+  background-color: #2d2d2d;
+  border: 1px solid #404040;
+}
+[data-theme="dark"] .post-container pre code,
+[data-theme="dark"] .postlist-container pre code {
+  background-color: transparent;
+  border: none;
+}
+[data-theme="dark"] .post-container table th,
+[data-theme="dark"] .postlist-container table th,
+[data-theme="dark"] .post-container table td,
+[data-theme="dark"] .postlist-container table td {
+  border: 1px solid #404040 !important;
+  background-color: #2d2d2d;
+}
+[data-theme="dark"] .post-container table thead th,
+[data-theme="dark"] .postlist-container table thead th {
+  background-color: #3a3a3a;
+}
+[data-theme="dark"] .post-container img,
+[data-theme="dark"] .postlist-container img {
+  opacity: 0.9;
+  transition: opacity 0.3s ease;
+}
+[data-theme="dark"] .post-container img:hover,
+[data-theme="dark"] .postlist-container img:hover {
+  opacity: 1;
+}
+[data-theme="dark"] .post-preview > a {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .post-preview > a:hover,
+[data-theme="dark"] .post-preview > a:focus {
+  color: #6eb5ff;
+  text-decoration: none;
+}
+[data-theme="dark"] .post-preview > a:hover > .post-title,
+[data-theme="dark"] .post-preview > a:focus > .post-title,
+[data-theme="dark"] .post-preview > a:hover > .post-subtitle,
+[data-theme="dark"] .post-preview > a:focus > .post-subtitle {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .post-preview > .post-meta {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-preview > .post-meta > a {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-preview > .post-meta > a:hover,
+[data-theme="dark"] .post-preview > .post-meta > a:focus {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .post-content-preview {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .post-content-preview:hover {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .sidebar-container {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .sidebar-container h5 {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .sidebar-container h5 a {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .sidebar-container h5 a:hover {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .sidebar-container .short-about {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .side-catalog {
+  background-color: #1a1a1a;
+  box-shadow: none;
+}
+[data-theme="dark"] .side-catalog h5 a {
+  color: #e0e0e0;
+}
+[data-theme="dark"] .side-catalog .catalog-body li a {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .side-catalog .catalog-body li a:hover {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .side-catalog .catalog-body li a.active {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .tags a,
+[data-theme="dark"] .tags .tag {
+  background-color: #2d2d2d;
+  border-color: #404040;
+  color: #e0e0e0;
+}
+[data-theme="dark"] .tags a:hover,
+[data-theme="dark"] .tags .tag:hover,
+[data-theme="dark"] .tags a:active,
+[data-theme="dark"] .tags .tag:active {
+  background-color: #6eb5ff;
+  border-color: #6eb5ff;
+  color: white !important;
+}
+[data-theme="dark"] hr,
+[data-theme="dark"] hr.small {
+  border-color: #404040;
+}
+[data-theme="dark"] .listing-seperator {
+  color: #6eb5ff;
+}
+[data-theme="dark"] .listing-seperator:hover {
+  color: #9fd3ff;
+}
+[data-theme="dark"] #tag_cloud a,
+[data-theme="dark"] #tag_cloud .tag {
+  color: #e0e0e0 !important;
+  border: none !important;
+}
+[data-theme="dark"] #tag_cloud a:hover,
+[data-theme="dark"] #tag_cloud .tag:hover,
+[data-theme="dark"] #tag_cloud a:active,
+[data-theme="dark"] #tag_cloud .tag:active {
+  color: white !important;
+  border: none !important;
+}
+[data-theme="dark"] .pager li > a,
+[data-theme="dark"] .pager li > span {
+  background-color: #2d2d2d;
+  border: 1px solid #404040;
+  color: #e0e0e0;
+}
+[data-theme="dark"] .pager li > a span,
+[data-theme="dark"] .pager li > span span {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .pager li > a:hover,
+[data-theme="dark"] .pager li > a:focus {
+  background-color: #6eb5ff;
+  border-color: #6eb5ff;
+  color: white;
+}
+[data-theme="dark"] .pager li > a:hover span,
+[data-theme="dark"] .pager li > a:focus span {
+  color: white;
+}
+[data-theme="dark"] .pager .disabled > a,
+[data-theme="dark"] .pager .disabled > a:hover,
+[data-theme="dark"] .pager .disabled > a:focus,
+[data-theme="dark"] .pager .disabled > span {
+  color: #b0b0b0 !important;
+  background-color: #2d2d2d !important;
+  cursor: not-allowed;
+}
+[data-theme="dark"] footer {
+  background-color: #2d2d2d;
+  border-top: 1px solid #404040;
+  color: #b0b0b0;
+}
+[data-theme="dark"] footer .copyright {
+  color: #b0b0b0;
+}
+[data-theme="dark"] footer .copyright a {
+  color: #6eb5ff;
+}
+[data-theme="dark"] footer .copyright a:hover,
+[data-theme="dark"] footer .copyright a:focus {
+  color: #9fd3ff;
+}
+[data-theme="dark"] input,
+[data-theme="dark"] textarea,
+[data-theme="dark"] select {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #404040;
+}
+[data-theme="dark"] input:focus,
+[data-theme="dark"] textarea:focus,
+[data-theme="dark"] select:focus {
+  background-color: #2d2d2d;
+  border-color: #6eb5ff;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-header-textarea {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #404040;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-comment {
+  background-color: #2d2d2d;
+  border-color: #404040;
+}
+[data-theme="dark"] #gitalk-container .gt-container .gt-comment .gt-comment-content {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+}
+[data-theme="dark"] #search-bar {
+  background-color: #2d2d2d !important;
+  color: #e0e0e0 !important;
+  border-color: #404040 !important;
+}
+[data-theme="dark"] #search-bar:focus {
+  background-color: #2d2d2d !important;
+  color: #e0e0e0 !important;
+  border-color: #6eb5ff !important;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
+}
+[data-theme="dark"] #search-bar:not(:focus) {
+  color: #e0e0e0 !important;
+}
+[data-theme="dark"] .form-control {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #404040;
+}
+[data-theme="dark"] .form-control:focus {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border-color: #6eb5ff;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6);
+}
+[data-theme="dark"] .form-control::placeholder {
+  color: #b0b0b0;
+}
+[data-theme="dark"] .btn-default {
+  background-color: #2d2d2d;
+  border-color: #404040;
+  color: #e0e0e0;
+}
+[data-theme="dark"] .btn-default:hover,
+[data-theme="dark"] .btn-default:focus {
+  background-color: #6eb5ff;
+  border-color: #6eb5ff;
+  color: white;
+}
+[data-theme="dark"] ::selection {
+  background: #6eb5ff;
+  color: white;
+}
+[data-theme="dark"] ::-moz-selection {
+  background: #6eb5ff;
+  color: white;
+}
 body {
-  /* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Arial", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Microsoft YaHei", "Microsoft JhengHei", "Source Han Sans SC", "Noto Sans CJK SC", "Source Han Sans CN", "Noto Sans SC", "Source Han Sans TC", "Noto Sans CJK TC", "WenQuanYi Micro Hei", SimSun, sans-serif;
   line-height: 1.7;
   font-size: 16px;
@@ -149,10 +481,6 @@ h3,
 h4,
 h5,
 h6 {
-  /* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Arial", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Microsoft YaHei", "Microsoft JhengHei", "Source Han Sans SC", "Noto Sans CJK SC", "Source Han Sans CN", "Noto Sans SC", "Source Han Sans TC", "Noto Sans CJK TC", "WenQuanYi Micro Hei", SimSun, sans-serif;
   line-height: 1.7;
   line-height: 1.1;
@@ -404,10 +732,6 @@ pre code {
   left: 0;
   width: 100%;
   z-index: 3;
-  /* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Arial", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Microsoft YaHei", "Microsoft JhengHei", "Source Han Sans SC", "Noto Sans CJK SC", "Source Han Sans CN", "Noto Sans SC", "Source Han Sans TC", "Noto Sans CJK TC", "WenQuanYi Micro Hei", SimSun, sans-serif;
   line-height: 1.7;
 }
@@ -555,10 +879,6 @@ pre code {
 }
 .intro-header .site-heading .subheading,
 .intro-header .page-heading .subheading {
-  /* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Arial", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Microsoft YaHei", "Microsoft JhengHei", "Source Han Sans SC", "Noto Sans CJK SC", "Source Han Sans CN", "Noto Sans SC", "Source Han Sans TC", "Noto Sans CJK TC", "WenQuanYi Micro Hei", SimSun, sans-serif;
   line-height: 1.7;
   font-size: 18px;
@@ -583,10 +903,6 @@ pre code {
   display: block;
 }
 .intro-header .post-heading .subheading {
-  /* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Arial", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Microsoft YaHei", "Microsoft JhengHei", "Source Han Sans SC", "Noto Sans CJK SC", "Source Han Sans CN", "Noto Sans SC", "Source Han Sans TC", "Noto Sans CJK TC", "WenQuanYi Micro Hei", SimSun, sans-serif;
   line-height: 1.7;
   font-size: 17px;
@@ -763,10 +1079,6 @@ form .row:first-child .floating-label-form-group {
   border-top: 1px solid #eee;
 }
 .btn {
-  /* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Arial", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Microsoft YaHei", "Microsoft JhengHei", "Source Han Sans SC", "Noto Sans CJK SC", "Source Han Sans CN", "Noto Sans SC", "Source Han Sans TC", "Noto Sans CJK TC", "WenQuanYi Micro Hei", SimSun, sans-serif;
   line-height: 1.7;
   text-transform: uppercase;
@@ -792,10 +1104,6 @@ form .row:first-child .floating-label-form-group {
 }
 .pager li > a,
 .pager li > span {
-  /* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Arial", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Microsoft YaHei", "Microsoft JhengHei", "Source Han Sans SC", "Noto Sans CJK SC", "Source Han Sans CN", "Noto Sans SC", "Source Han Sans TC", "Noto Sans CJK TC", "WenQuanYi Micro Hei", SimSun, sans-serif;
   line-height: 1.7;
   text-transform: uppercase;
@@ -833,6 +1141,7 @@ form .row:first-child .floating-label-form-group {
   color: #808080;
   background-color: #404040;
   cursor: not-allowed;
+  pointer-events: none;
 }
 ::-moz-selection {
   text-shadow: none;
@@ -900,13 +1209,6 @@ img::-moz-selection {
   line-height: 28px;
   margin: 0 2px;
   margin-bottom: 8px;
-  background: #D6D6D6;
-}
-#tag_cloud a:hover,
-#tag_cloud .tag:hover,
-#tag_cloud a:active,
-#tag_cloud .tag:active {
-  background-color: #0085a1 !important;
 }
 @media only screen and (min-width: 768px) {
   #tag_cloud {
@@ -939,10 +1241,6 @@ img::-moz-selection {
 }
 .one-tag-list .tag-text {
   font-weight: 200;
-  /* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Arial", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Microsoft YaHei", "Microsoft JhengHei", "Source Han Sans SC", "Noto Sans CJK SC", "Source Han Sans CN", "Noto Sans SC", "Source Han Sans TC", "Noto Sans CJK TC", "WenQuanYi Micro Hei", SimSun, sans-serif;
   line-height: 1.7;
 }

--- a/css/hux-blog.css
+++ b/css/hux-blog.css
@@ -265,7 +265,9 @@
   text-decoration: none;
 }
 [data-theme="dark"] .post-preview > a:hover > .post-title,
-[data-theme="dark"] .post-preview > a:focus > .post-title {
+[data-theme="dark"] .post-preview > a:focus > .post-title,
+[data-theme="dark"] .post-preview > a:hover > .post-subtitle,
+[data-theme="dark"] .post-preview > a:focus > .post-subtitle {
   color: #a78bfa;
 }
 [data-theme="dark"] .post-preview > .post-meta {

--- a/css/hux-blog.css
+++ b/css/hux-blog.css
@@ -119,7 +119,7 @@
 }
 .side-catalog .catalog-body .active {
   border-radius: 4px;
-  background-color: #F5F5F5;
+  background-color: #3d2d5d;
 }
 .side-catalog .catalog-body .active a {
   color: #c4b5fd !important;
@@ -316,7 +316,7 @@
   color: #c4b5fd;
 }
 [data-theme="dark"] .side-catalog .catalog-body li.active {
-  background-color: #2d1b4e;
+  background-color: #3d2d5d;
   border-radius: 4px;
 }
 [data-theme="dark"] .tags a,

--- a/css/hux-blog.css
+++ b/css/hux-blog.css
@@ -340,6 +340,32 @@
   border-color: #a78bfa;
   color: white !important;
 }
+[data-theme="dark"] .post-heading .tags a,
+[data-theme="dark"] .page-heading .tags a,
+[data-theme="dark"] .site-heading .tags a,
+[data-theme="dark"] .post-heading .tags .tag,
+[data-theme="dark"] .page-heading .tags .tag,
+[data-theme="dark"] .site-heading .tags .tag {
+  background-color: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.9);
+}
+[data-theme="dark"] .post-heading .tags a:hover,
+[data-theme="dark"] .page-heading .tags a:hover,
+[data-theme="dark"] .site-heading .tags a:hover,
+[data-theme="dark"] .post-heading .tags .tag:hover,
+[data-theme="dark"] .page-heading .tags .tag:hover,
+[data-theme="dark"] .site-heading .tags .tag:hover,
+[data-theme="dark"] .post-heading .tags a:active,
+[data-theme="dark"] .page-heading .tags a:active,
+[data-theme="dark"] .site-heading .tags a:active,
+[data-theme="dark"] .post-heading .tags .tag:active,
+[data-theme="dark"] .page-heading .tags .tag:active,
+[data-theme="dark"] .site-heading .tags .tag:active {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.6);
+  color: white !important;
+}
 [data-theme="dark"] hr,
 [data-theme="dark"] hr.small {
   border-color: #3d2d5d;

--- a/css/hux-blog.css
+++ b/css/hux-blog.css
@@ -146,6 +146,12 @@
 }
 [data-theme="dark"] a {
   color: #a78bfa;
+  transition: all 0.4s ease;
+  -moz-transition: all 0.4s ease;
+  /* Firefox 4 */
+  -webkit-transition: all 0.4s ease;
+  /* Safari 和 Chrome */
+  -o-transition: all 0.4s ease;
 }
 [data-theme="dark"] a:hover,
 [data-theme="dark"] a:focus {
@@ -257,7 +263,6 @@
 }
 [data-theme="dark"] .post-preview > a {
   color: #e8dff5;
-  transition: all 0.4s ease;
 }
 [data-theme="dark"] .post-preview > a:hover,
 [data-theme="dark"] .post-preview > a:focus {

--- a/css/hux-blog.css
+++ b/css/hux-blog.css
@@ -122,7 +122,7 @@
   background-color: #F5F5F5;
 }
 .side-catalog .catalog-body .active a {
-  color: #0085a1 !important;
+  color: #c4b5fd !important;
 }
 @media (max-width: 1200px) {
   .side-catalog {
@@ -130,8 +130,11 @@
   }
 }
 [data-theme="dark"] body {
-  background-color: #1a1a1a;
-  color: #e0e0e0;
+  background-color: #1a0f2e;
+  color: #e8dff5;
+  --tagcloud-light-color: #b8a8d8;
+  --tagcloud-dark-color: #7a5fa8;
+  --accent-color: #c4b5fd;
 }
 [data-theme="dark"] h1,
 [data-theme="dark"] h2,
@@ -139,40 +142,40 @@
 [data-theme="dark"] h4,
 [data-theme="dark"] h5,
 [data-theme="dark"] h6 {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] a {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] a:hover,
 [data-theme="dark"] a:focus {
-  color: #9fd3ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] .navbar-custom {
-  background-color: rgba(45, 45, 45, 0.95);
-  border-bottom: 1px solid #404040;
+  background-color: rgba(45, 27, 78, 0.95);
+  border-bottom: 1px solid #3d2d5d;
 }
 [data-theme="dark"] .navbar-custom.is-fixed {
-  background-color: rgba(45, 45, 45, 0.95);
-  border-bottom: 1px solid #404040;
+  background-color: rgba(45, 27, 78, 0.95);
+  border-bottom: 1px solid #3d2d5d;
 }
 [data-theme="dark"] .navbar-custom.is-fixed .navbar-brand {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .navbar-custom.is-fixed .navbar-brand:hover,
 [data-theme="dark"] .navbar-custom.is-fixed .navbar-brand:focus {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .navbar-custom.is-fixed .nav li a {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .navbar-custom.is-fixed .nav li a:hover,
 [data-theme="dark"] .navbar-custom.is-fixed .nav li a:focus {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 @media only screen and (max-width: 767px) {
   [data-theme="dark"] .navbar-default .navbar-collapse {
-    background: #2d2d2d;
+    background: #2d1b4e;
     box-shadow: 0px 5px 10px 2px rgba(0, 0, 0, 0.5);
   }
 }
@@ -192,40 +195,40 @@
 }
 [data-theme="dark"] .post-container,
 [data-theme="dark"] .postlist-container {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .post-container a,
 [data-theme="dark"] .postlist-container a {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .post-container a:hover,
 [data-theme="dark"] .postlist-container a:hover,
 [data-theme="dark"] .post-container a:focus,
 [data-theme="dark"] .postlist-container a:focus {
-  color: #9fd3ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] .post-container h5,
 [data-theme="dark"] .postlist-container h5,
 [data-theme="dark"] .post-container h6,
 [data-theme="dark"] .postlist-container h6 {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-container blockquote,
 [data-theme="dark"] .postlist-container blockquote {
-  background-color: #252525;
-  border-left: 4px solid #404040;
-  color: #b0b0b0;
+  background-color: #251a42;
+  border-left: 4px solid #3d2d5d;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-container code,
 [data-theme="dark"] .postlist-container code {
-  background-color: #2d2d2d;
+  background-color: #2d1b4e;
   color: #ff6b6b;
-  border: 1px solid #404040;
+  border: 1px solid #3d2d5d;
 }
 [data-theme="dark"] .post-container pre,
 [data-theme="dark"] .postlist-container pre {
-  background-color: #2d2d2d;
-  border: 1px solid #404040;
+  background-color: #2d1b4e;
+  border: 1px solid #3d2d5d;
 }
 [data-theme="dark"] .post-container pre code,
 [data-theme="dark"] .postlist-container pre code {
@@ -236,8 +239,8 @@
 [data-theme="dark"] .postlist-container table th,
 [data-theme="dark"] .post-container table td,
 [data-theme="dark"] .postlist-container table td {
-  border: 1px solid #404040 !important;
-  background-color: #2d2d2d;
+  border: 1px solid #3d2d5d !important;
+  background-color: #2d1b4e;
 }
 [data-theme="dark"] .post-container table thead th,
 [data-theme="dark"] .postlist-container table thead th {
@@ -253,93 +256,96 @@
   opacity: 1;
 }
 [data-theme="dark"] .post-preview > a {
-  color: #e0e0e0;
+  color: #e8dff5;
+  transition: all 0.4s ease;
 }
 [data-theme="dark"] .post-preview > a:hover,
 [data-theme="dark"] .post-preview > a:focus {
-  color: #6eb5ff;
+  color: #a78bfa;
   text-decoration: none;
 }
 [data-theme="dark"] .post-preview > a:hover > .post-title,
-[data-theme="dark"] .post-preview > a:focus > .post-title,
-[data-theme="dark"] .post-preview > a:hover > .post-subtitle,
-[data-theme="dark"] .post-preview > a:focus > .post-subtitle {
-  color: #6eb5ff;
+[data-theme="dark"] .post-preview > a:focus > .post-title {
+  color: #a78bfa;
 }
 [data-theme="dark"] .post-preview > .post-meta {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-preview > .post-meta > a {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-preview > .post-meta > a:hover,
 [data-theme="dark"] .post-preview > .post-meta > a:focus {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .post-content-preview {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .post-content-preview:hover {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .sidebar-container {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .sidebar-container h5 {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .sidebar-container h5 a {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .sidebar-container h5 a:hover {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .sidebar-container .short-about {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .side-catalog {
-  background-color: #1a1a1a;
+  background-color: #1a0f2e;
   box-shadow: none;
 }
 [data-theme="dark"] .side-catalog h5 a {
-  color: #e0e0e0;
+  color: #e8dff5;
 }
 [data-theme="dark"] .side-catalog .catalog-body li a {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .side-catalog .catalog-body li a:hover {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] .side-catalog .catalog-body li a.active {
-  color: #6eb5ff;
+  color: #c4b5fd;
+}
+[data-theme="dark"] .side-catalog .catalog-body li.active {
+  background-color: #2d1b4e;
+  border-radius: 4px;
 }
 [data-theme="dark"] .tags a,
 [data-theme="dark"] .tags .tag {
-  background-color: #2d2d2d;
-  border-color: #404040;
-  color: #e0e0e0;
+  background-color: #2d1b4e;
+  border-color: #3d2d5d;
+  color: #e8dff5;
 }
 [data-theme="dark"] .tags a:hover,
 [data-theme="dark"] .tags .tag:hover,
 [data-theme="dark"] .tags a:active,
 [data-theme="dark"] .tags .tag:active {
-  background-color: #6eb5ff;
-  border-color: #6eb5ff;
+  background-color: #a78bfa;
+  border-color: #a78bfa;
   color: white !important;
 }
 [data-theme="dark"] hr,
 [data-theme="dark"] hr.small {
-  border-color: #404040;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] .listing-seperator {
-  color: #6eb5ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] .listing-seperator:hover {
-  color: #9fd3ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] #tag_cloud a,
 [data-theme="dark"] #tag_cloud .tag {
-  color: #e0e0e0 !important;
+  color: #e8dff5 !important;
   border: none !important;
 }
 [data-theme="dark"] #tag_cloud a:hover,
@@ -351,18 +357,18 @@
 }
 [data-theme="dark"] .pager li > a,
 [data-theme="dark"] .pager li > span {
-  background-color: #2d2d2d;
-  border: 1px solid #404040;
-  color: #e0e0e0;
+  background-color: #2d1b4e;
+  border: 1px solid #3d2d5d;
+  color: #e8dff5;
 }
 [data-theme="dark"] .pager li > a span,
 [data-theme="dark"] .pager li > span span {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .pager li > a:hover,
 [data-theme="dark"] .pager li > a:focus {
-  background-color: #6eb5ff;
-  border-color: #6eb5ff;
+  background-color: #a78bfa;
+  border-color: #a78bfa;
   color: white;
 }
 [data-theme="dark"] .pager li > a:hover span,
@@ -373,97 +379,98 @@
 [data-theme="dark"] .pager .disabled > a:hover,
 [data-theme="dark"] .pager .disabled > a:focus,
 [data-theme="dark"] .pager .disabled > span {
-  color: #808080 !important;
-  background-color: #1f1f1f !important;
+  color: #8b7ba8 !important;
+  background-color: #1f1535 !important;
+  border-color: #3d2d5d !important;
   cursor: not-allowed !important;
   pointer-events: none !important;
 }
 [data-theme="dark"] footer {
-  background-color: #2d2d2d;
-  border-top: 1px solid #404040;
-  color: #b0b0b0;
+  background-color: #2d1b4e;
+  border-top: 1px solid #3d2d5d;
+  color: #b8a8d8;
 }
 [data-theme="dark"] footer .copyright {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] footer .copyright a {
-  color: #6eb5ff;
+  color: #a78bfa;
 }
 [data-theme="dark"] footer .copyright a:hover,
 [data-theme="dark"] footer .copyright a:focus {
-  color: #9fd3ff;
+  color: #c4b5fd;
 }
 [data-theme="dark"] input,
 [data-theme="dark"] textarea,
 [data-theme="dark"] select {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #404040;
+  background-color: #2d1b4e;
+  color: #e8dff5;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] input:focus,
 [data-theme="dark"] textarea:focus,
 [data-theme="dark"] select:focus {
-  background-color: #2d2d2d;
-  border-color: #6eb5ff;
+  background-color: #2d1b4e;
+  border-color: #a78bfa;
 }
 [data-theme="dark"] #gitalk-container .gt-container .gt-header-textarea {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #404040;
+  background-color: #2d1b4e;
+  color: #e8dff5;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] #gitalk-container .gt-container .gt-comment {
-  background-color: #2d2d2d;
-  border-color: #404040;
+  background-color: #2d1b4e;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] #gitalk-container .gt-container .gt-comment .gt-comment-content {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
+  background-color: #2d1b4e;
+  color: #e8dff5;
 }
 [data-theme="dark"] #search-bar {
-  background-color: #2d2d2d !important;
-  color: #e0e0e0 !important;
-  border-color: #404040 !important;
+  background-color: #2d1b4e !important;
+  color: #e8dff5 !important;
+  border-color: #3d2d5d !important;
 }
 [data-theme="dark"] #search-bar:focus {
-  background-color: #2d2d2d !important;
-  color: #e0e0e0 !important;
-  border-color: #6eb5ff !important;
+  background-color: #2d1b4e !important;
+  color: #e8dff5 !important;
+  border-color: #a78bfa !important;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
 }
 [data-theme="dark"] #search-bar:not(:focus) {
-  color: #e0e0e0 !important;
+  color: #e8dff5 !important;
 }
 [data-theme="dark"] .form-control {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #404040;
+  background-color: #2d1b4e;
+  color: #e8dff5;
+  border-color: #3d2d5d;
 }
 [data-theme="dark"] .form-control:focus {
-  background-color: #2d2d2d;
-  color: #e0e0e0;
-  border-color: #6eb5ff;
+  background-color: #2d1b4e;
+  color: #e8dff5;
+  border-color: #a78bfa;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(107, 181, 255, 0.6);
 }
 [data-theme="dark"] .form-control::placeholder {
-  color: #b0b0b0;
+  color: #b8a8d8;
 }
 [data-theme="dark"] .btn-default {
-  background-color: #2d2d2d;
-  border-color: #404040;
-  color: #e0e0e0;
+  background-color: #2d1b4e;
+  border-color: #3d2d5d;
+  color: #e8dff5;
 }
 [data-theme="dark"] .btn-default:hover,
 [data-theme="dark"] .btn-default:focus {
-  background-color: #6eb5ff;
-  border-color: #6eb5ff;
+  background-color: #a78bfa;
+  border-color: #a78bfa;
   color: white;
 }
 [data-theme="dark"] ::selection {
-  background: #6eb5ff;
+  background: #a78bfa;
   color: white;
 }
 [data-theme="dark"] ::-moz-selection {
-  background: #6eb5ff;
+  background: #a78bfa;
   color: white;
 }
 body {
@@ -472,6 +479,9 @@ body {
   font-size: 16px;
   color: #404040;
   overflow-x: hidden;
+  --tagcloud-light-color: #bbbbee;
+  --tagcloud-dark-color: #0085a1;
+  --accent-color: #0085a1;
 }
 p {
   margin: 30px 0;
@@ -1140,7 +1150,7 @@ form .row:first-child .floating-label-form-group {
 .pager .disabled > a:focus,
 .pager .disabled > span {
   color: #808080;
-  background-color: #ccd0d3;
+  background-color: #1f1535;
   cursor: not-allowed;
   pointer-events: none;
 }
@@ -1228,7 +1238,7 @@ img::-moz-selection {
   margin-top: 0px;
 }
 .listing-seperator {
-  color: #0085a1;
+  color: #c4b5fd;
   font-size: 21px !important;
 }
 .listing-seperator::before {

--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@ description: "吹学著作集锦"
         <a href="{{ paginator.previous_page_path | prepend: site.baseurl }}">&lsaquo;</a>
     </li>
     {% else %}
-    <li class="previous">
-        <a style="pointer-events:none;background-color: #ccd0d3">&lsaquo;&lsaquo;</a>
+    <li class="previous disabled">
+        <a>&lsaquo;&lsaquo;</a>
     </li>
-    <li class="previous">
-        <a style="pointer-events:none;background-color: #ccd0d3">&lsaquo;</a>
+    <li class="previous disabled">
+        <a>&lsaquo;</a>
     </li>
     {% endif %}
 
@@ -71,11 +71,11 @@ description: "吹学著作集锦"
         <a href="{{ paginator.next_page_path | prepend: site.baseurl }}">&rsaquo;</a>
     </li>
     {% else %}
-    <li class="next">
-        <a style="pointer-events:none;background-color: #ccd0d3">&rsaquo;&rsaquo;</a>
+    <li class="next disabled">
+        <a>&rsaquo;&rsaquo;</a>
     </li>
-    <li class="next">
-        <a style="pointer-events:none;background-color: #ccd0d3">&rsaquo;</a>
+    <li class="next disabled">
+        <a>&rsaquo;</a>
     </li>
     {% endif %}
 </ul>

--- a/less/colors.less
+++ b/less/colors.less
@@ -1,0 +1,72 @@
+// Color Variables for Light and Dark Modes
+
+// ============================================
+// Light Mode Colors
+// ============================================
+
+// Background colors
+@light-bg: white;
+@light-bg-secondary: #f5f5f5;
+
+// Text colors
+@light-text: #404040;  // lighten(black, 25%)
+@light-text-secondary: #808080;  // lighten(black, 50%)
+
+// Border colors
+@light-border: #ddd;
+
+// Link colors
+@light-link: #33ADFF;
+@light-link-hover: #0085a1;
+
+// Code colors
+@light-code-bg: #f5f5f5;
+@light-blockquote-bg: #f9f9f9;
+
+// Disabled state colors
+@light-disabled-bg: #ccd0d3;
+@light-disabled-text: #808080;
+
+// Tag cloud gradient colors (light mode)
+// 热度越高颜色越深：浅色 -> 深色
+@light-tagcloud-light-color: #bbbbee;
+@light-tagcloud-dark-color: #0085a1;
+
+// Accent color for light mode (used in side-catalog, listing-seperator, etc.)
+@light-accent-color: #0085a1;
+
+// ============================================
+// Dark Mode Colors
+// ============================================
+
+// Background colors
+@dark-bg: #1a0f2e;
+@dark-bg-secondary: #2d1b4e;
+
+// Text colors
+@dark-text: #e8dff5;
+@dark-text-secondary: #b8a8d8;
+
+// Border colors
+@dark-border: #3d2d5d;
+
+// Link colors
+@dark-link: #a78bfa;
+@dark-link-hover: #c4b5fd;
+
+// Code colors
+@dark-code-bg: #2d1b4e;
+@dark-blockquote-bg: #251a42;
+
+// Disabled state colors
+@dark-disabled-bg: #1f1535;
+@dark-disabled-text: #8b7ba8;
+
+// Tag cloud gradient colors (dark mode)
+// 热度越高颜色越深：浅紫 -> 深紫（与背景协调）
+@dark-tagcloud-light-color: #b8a8d8;
+@dark-tagcloud-dark-color: #7a5fa8;
+
+// Accent color for dark mode (used in side-catalog, listing-seperator, etc.)
+@dark-accent-color: #c4b5fd;
+

--- a/less/colors.less
+++ b/less/colors.less
@@ -35,6 +35,9 @@
 // Accent color for light mode (used in side-catalog, listing-seperator, etc.)
 @light-accent-color: #0085a1;
 
+// Side catalog active background color (light mode)
+@light-catalog-active-bg: #F5F5F5;
+
 // ============================================
 // Dark Mode Colors
 // ============================================
@@ -69,4 +72,8 @@
 
 // Accent color for dark mode (used in side-catalog, listing-seperator, etc.)
 @dark-accent-color: #c4b5fd;
+
+// Side catalog active background color (dark mode)
+// 比背景深色稍亮，显得没有那么突兀
+@dark-catalog-active-bg: #3d2d5d;
 

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -397,23 +397,4 @@
     background: @dark-link;
     color: white;
   }
-
-  // Scrollbar (Webkit)
-  ::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: @dark-bg;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: @dark-bg-secondary;
-    border-radius: 5px;
-
-    &:hover {
-      background: #4a4a4a;
-    }
-  }
 }

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -1,27 +1,38 @@
 // Dark Mode Styles for Hibikilogy
 
-// Dark mode color variables
-@dark-bg: #1a1a1a;
-@dark-bg-secondary: #2d2d2d;
-@dark-text: #e0e0e0;
-@dark-text-secondary: #b0b0b0;
-@dark-border: #404040;
-@dark-link: #6eb5ff;
-@dark-link-hover: #9fd3ff;
-@dark-code-bg: #2d2d2d;
-@dark-blockquote-bg: #252525;
+// Import color variables
+@import "colors.less";
 
-// Disabled state colors
-@dark-disabled-bg: #1f1f1f;
-@dark-disabled-text: #808080;
+// Override with dark mode colors
+@bg: @dark-bg;
+@bg-secondary: @dark-bg-secondary;
+@text: @dark-text;
+@text-secondary: @dark-text-secondary;
+@border: @dark-border;
+@link: @dark-link;
+@link-hover: @dark-link-hover;
+@code-bg: @dark-code-bg;
+@blockquote-bg: @dark-blockquote-bg;
+@disabled-bg: @dark-disabled-bg;
+@disabled-text: @dark-disabled-text;
+@tagcloud-light-color: @dark-tagcloud-light-color;
+@tagcloud-dark-color: @dark-tagcloud-dark-color;
+@accent-color: @dark-accent-color;
 
 // Dark mode styles
 [data-theme="dark"] {
 
   // Base styles
   body {
-    background-color: @dark-bg;
-    color: @dark-text;
+    background-color: @bg;
+    color: @text;
+
+    // Tag cloud gradient colors (CSS variables for dark mode)
+    --tagcloud-light-color: @dark-tagcloud-light-color;
+    --tagcloud-dark-color: @dark-tagcloud-dark-color;
+    
+    // Accent color for dark mode
+    --accent-color: @dark-accent-color;
   }
 
   // Typography
@@ -31,42 +42,42 @@
   h4,
   h5,
   h6 {
-    color: @dark-text;
+    color: @text;
   }
 
   a {
-    color: @dark-link;
+    color: @link;
 
     &:hover,
     &:focus {
-      color: @dark-link-hover;
+      color: @link-hover;
     }
   }
 
   // Navigation
   .navbar-custom {
-    background-color: fade(@dark-bg-secondary, 95%);
-    border-bottom: 1px solid @dark-border;
+    background-color: fade(@bg-secondary, 95%);
+    border-bottom: 1px solid @border;
 
     &.is-fixed {
-      background-color: fade(@dark-bg-secondary, 95%);
-      border-bottom: 1px solid @dark-border;
+      background-color: fade(@bg-secondary, 95%);
+      border-bottom: 1px solid @border;
 
       .navbar-brand {
-        color: @dark-text;
+        color: @text;
 
         &:hover,
         &:focus {
-          color: @dark-link;
+          color: @link;
         }
       }
 
       .nav li a {
-        color: @dark-text;
+        color: @text;
 
         &:hover,
         &:focus {
-          color: @dark-link;
+          color: @link;
         }
       }
     }
@@ -74,7 +85,7 @@
 
   @media only screen and (max-width: 767px) {
     .navbar-default .navbar-collapse {
-      background: @dark-bg-secondary;
+      background: @bg-secondary;
       box-shadow: 0px 5px 10px 2px rgba(0, 0, 0, 0.5);
     }
   }
@@ -98,37 +109,37 @@
   // Post content
   .post-container,
   .postlist-container {
-    color: @dark-text;
+    color: @text;
 
     a {
-      color: @dark-link;
+      color: @link;
 
       &:hover,
       &:focus {
-        color: @dark-link-hover;
+        color: @link-hover;
       }
     }
 
     h5,
     h6 {
-      color: @dark-text-secondary;
+      color: @text-secondary;
     }
 
     blockquote {
-      background-color: @dark-blockquote-bg;
-      border-left: 4px solid @dark-border;
-      color: @dark-text-secondary;
+      background-color: @blockquote-bg;
+      border-left: 4px solid @border;
+      color: @text-secondary;
     }
 
     code {
-      background-color: @dark-code-bg;
+      background-color: @code-bg;
       color: #ff6b6b;
-      border: 1px solid @dark-border;
+      border: 1px solid @border;
     }
 
     pre {
-      background-color: @dark-code-bg;
-      border: 1px solid @dark-border;
+      background-color: @code-bg;
+      border: 1px solid @border;
 
       code {
         background-color: transparent;
@@ -140,8 +151,8 @@
 
       th,
       td {
-        border: 1px solid @dark-border !important;
-        background-color: @dark-bg-secondary;
+        border: 1px solid @border !important;
+        background-color: @bg-secondary;
       }
 
       thead th {
@@ -162,84 +173,89 @@
   // Post preview
   .post-preview {
     >a {
-      color: @dark-text;
+      color: @text;
+      transition: all 0.4s ease;
 
       &:hover,
       &:focus {
-        color: @dark-link;
+        color: @link;
         text-decoration: none;
 
-        >.post-title,
-        >.post-subtitle {
-          color: @dark-link;
+        >.post-title {
+          color: @link;
         }
       }
     }
 
     >.post-meta {
-      color: @dark-text-secondary;
+      color: @text-secondary;
 
       >a {
-        color: @dark-text-secondary;
+        color: @text-secondary;
 
         &:hover,
         &:focus {
-          color: @dark-link;
+          color: @link;
         }
       }
     }
   }
 
   .post-content-preview {
-    color: @dark-text-secondary;
+    color: @text-secondary;
 
     &:hover {
-      color: @dark-link;
+      color: @link;
     }
   }
 
   // Sidebar
   .sidebar-container {
-    color: @dark-text;
+    color: @text;
 
     h5 {
-      color: @dark-text;
+      color: @text;
 
       a {
-        color: @dark-text;
+        color: @text;
 
         &:hover {
-          color: @dark-link;
+          color: @link;
         }
       }
     }
 
     .short-about {
-      color: @dark-text-secondary;
+      color: @text-secondary;
     }
   }
 
   // Side catalog
   .side-catalog {
-    background-color: @dark-bg;
+    background-color: @bg;
     box-shadow: none;
 
     h5 a {
-      color: @dark-text;
+      color: @text;
     }
 
     .catalog-body {
       li {
         a {
-          color: @dark-text-secondary;
+          color: @text-secondary;
 
           &:hover {
-            color: @dark-link;
+            color: @link;
           }
 
           &.active {
-            color: @dark-link;
+            color: @accent-color;
           }
+        }
+        
+        &.active {
+          background-color: @bg-secondary;
+          border-radius: 4px;
         }
       }
     }
@@ -250,14 +266,14 @@
 
     a,
     .tag {
-      background-color: @dark-bg-secondary;
-      border-color: @dark-border;
-      color: @dark-text;
+      background-color: @bg-secondary;
+      border-color: @border;
+      color: @text;
 
       &:hover,
       &:active {
-        background-color: @dark-link;
-        border-color: @dark-link;
+        background-color: @link;
+        border-color: @link;
         color: white !important;
       }
     }
@@ -266,15 +282,15 @@
   // Horizontal rules
   hr,
   hr.small {
-    border-color: @dark-border;
+    border-color: @border;
   }
 
   // Tag listing separator
   .listing-seperator {
-    color: @dark-link;
+    color: @accent-color;
 
     &:hover {
-      color: @dark-link-hover;
+      color: @link-hover;
     }
   }
 
@@ -282,7 +298,7 @@
 
     a,
     .tag {
-      color: @dark-text !important;
+      color: @text !important;
       border: none !important;
 
       &:hover,
@@ -299,19 +315,19 @@
 
       >a,
       >span {
-        background-color: @dark-bg-secondary;
-        border: 1px solid @dark-border;
-        color: @dark-text;
+        background-color: @bg-secondary;
+        border: 1px solid @border;
+        color: @text;
 
         span {
-          color: @dark-text-secondary;
+          color: @text-secondary;
         }
       }
 
       >a:hover,
       >a:focus {
-        background-color: @dark-link;
-        border-color: @dark-link;
+        background-color: @link;
+        border-color: @link;
         color: white;
 
         span {
@@ -326,8 +342,9 @@
       >a:hover,
       >a:focus,
       >span {
-        color: @dark-disabled-text !important;
-        background-color: @dark-disabled-bg !important;
+        color: @disabled-text !important;
+        background-color: @disabled-bg !important;
+        border-color: @border !important;
         cursor: not-allowed !important;
         pointer-events: none !important;
       }
@@ -336,19 +353,19 @@
 
   // Footer
   footer {
-    background-color: @dark-bg-secondary;
-    border-top: 1px solid @dark-border;
-    color: @dark-text-secondary;
+    background-color: @bg-secondary;
+    border-top: 1px solid @border;
+    color: @text-secondary;
 
     .copyright {
-      color: @dark-text-secondary;
+      color: @text-secondary;
 
       a {
-        color: @dark-link;
+        color: @link;
 
         &:hover,
         &:focus {
-          color: @dark-link-hover;
+          color: @link-hover;
         }
       }
     }
@@ -358,13 +375,13 @@
   input,
   textarea,
   select {
-    background-color: @dark-bg-secondary;
-    color: @dark-text;
-    border-color: @dark-border;
+    background-color: @bg-secondary;
+    color: @text;
+    border-color: @border;
 
     &:focus {
-      background-color: @dark-bg-secondary;
-      border-color: @dark-link;
+      background-color: @bg-secondary;
+      border-color: @link;
     }
   }
 
@@ -372,18 +389,18 @@
   #gitalk-container {
     .gt-container {
       .gt-header-textarea {
-        background-color: @dark-bg-secondary;
-        color: @dark-text;
-        border-color: @dark-border;
+        background-color: @bg-secondary;
+        color: @text;
+        border-color: @border;
       }
 
       .gt-comment {
-        background-color: @dark-bg-secondary;
-        border-color: @dark-border;
+        background-color: @bg-secondary;
+        border-color: @border;
 
         .gt-comment-content {
-          background-color: @dark-bg-secondary;
-          color: @dark-text;
+          background-color: @bg-secondary;
+          color: @text;
         }
       }
     }
@@ -391,62 +408,62 @@
 
   // Search bar
   #search-bar {
-    background-color: @dark-bg-secondary !important;
-    color: @dark-text !important;
-    border-color: @dark-border !important;
+    background-color: @bg-secondary !important;
+    color: @text !important;
+    border-color: @border !important;
 
     &:focus {
-      background-color: @dark-bg-secondary !important;
-      color: @dark-text !important;
-      border-color: @dark-link !important;
+      background-color: @bg-secondary !important;
+      color: @text !important;
+      border-color: @link !important;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
     }
-
+    
     &:not(:focus) {
-      color: @dark-text !important;
+      color: @text !important;
     }
   }
 
   // Form control
   .form-control {
-    background-color: @dark-bg-secondary;
-    color: @dark-text;
-    border-color: @dark-border;
+    background-color: @bg-secondary;
+    color: @text;
+    border-color: @border;
 
     &:focus {
-      background-color: @dark-bg-secondary;
-      color: @dark-text;
-      border-color: @dark-link;
+      background-color: @bg-secondary;
+      color: @text;
+      border-color: @link;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(107, 181, 255, 0.6);
     }
 
     &::placeholder {
-      color: @dark-text-secondary;
+      color: @text-secondary;
     }
   }
 
   // Buttons
   .btn-default {
-    background-color: @dark-bg-secondary;
-    border-color: @dark-border;
-    color: @dark-text;
+    background-color: @bg-secondary;
+    border-color: @border;
+    color: @text;
 
     &:hover,
     &:focus {
-      background-color: @dark-link;
-      border-color: @dark-link;
+      background-color: @link;
+      border-color: @link;
       color: white;
     }
   }
 
   // Selection
   ::selection {
-    background: @dark-link;
+    background: @link;
     color: white;
   }
 
   ::-moz-selection {
-    background: @dark-link;
+    background: @link;
     color: white;
   }
 }

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -399,6 +399,10 @@
       border-color: @dark-link !important;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
     }
+    
+    &:not(:focus) {
+      color: @dark-text !important;
+    }
   }
 
   // Form control

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -13,7 +13,7 @@
 
 // Dark mode styles
 [data-theme="dark"] {
-  
+
   // Base styles
   body {
     background-color: @dark-bg;
@@ -21,13 +21,20 @@
   }
 
   // Typography
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     color: @dark-text;
   }
 
   a {
     color: @dark-link;
-    &:hover, &:focus {
+
+    &:hover,
+    &:focus {
       color: @dark-link-hover;
     }
   }
@@ -43,14 +50,18 @@
 
       .navbar-brand {
         color: @dark-text;
-        &:hover, &:focus {
+
+        &:hover,
+        &:focus {
           color: @dark-link;
         }
       }
 
       .nav li a {
         color: @dark-text;
-        &:hover, &:focus {
+
+        &:hover,
+        &:focus {
           color: @dark-link;
         }
       }
@@ -66,25 +77,36 @@
 
   // Header
   .intro-header {
-    .post-heading, .page-heading, .site-heading {
-      h1, h2, .subheading, .meta {
+
+    .post-heading,
+    .page-heading,
+    .site-heading {
+
+      h1,
+      h2,
+      .subheading,
+      .meta {
         text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
       }
     }
   }
 
   // Post content
-  .post-container, .postlist-container {
+  .post-container,
+  .postlist-container {
     color: @dark-text;
 
     a {
       color: @dark-link;
-      &:hover, &:focus {
+
+      &:hover,
+      &:focus {
         color: @dark-link-hover;
       }
     }
 
-    h5, h6 {
+    h5,
+    h6 {
       color: @dark-text-secondary;
     }
 
@@ -103,7 +125,7 @@
     pre {
       background-color: @dark-code-bg;
       border: 1px solid @dark-border;
-      
+
       code {
         background-color: transparent;
         border: none;
@@ -111,11 +133,13 @@
     }
 
     table {
-      th, td {
+
+      th,
+      td {
         border: 1px solid @dark-border !important;
         background-color: @dark-bg-secondary;
       }
-      
+
       thead th {
         background-color: #3a3a3a;
       }
@@ -124,7 +148,7 @@
     img {
       opacity: 0.9;
       transition: opacity 0.3s ease;
-      
+
       &:hover {
         opacity: 1;
       }
@@ -133,24 +157,29 @@
 
   // Post preview
   .post-preview {
-    > a {
+    >a {
       color: @dark-text;
-      &:hover, &:focus {
+
+      &:hover,
+      &:focus {
         color: @dark-link;
         text-decoration: none;
-        
-        > .post-title {
+
+        >.post-title,
+        >.post-subtitle {
           color: @dark-link;
         }
       }
     }
 
-    > .post-meta {
+    >.post-meta {
       color: @dark-text-secondary;
-      
-      > a {
+
+      >a {
         color: @dark-text-secondary;
-        &:hover, &:focus {
+
+        &:hover,
+        &:focus {
           color: @dark-link;
         }
       }
@@ -159,6 +188,7 @@
 
   .post-content-preview {
     color: @dark-text-secondary;
+
     &:hover {
       color: @dark-link;
     }
@@ -170,9 +200,10 @@
 
     h5 {
       color: @dark-text;
-      
+
       a {
         color: @dark-text;
+
         &:hover {
           color: @dark-link;
         }
@@ -187,8 +218,7 @@
   // Side catalog
   .side-catalog {
     background-color: @dark-bg;
-    border: 1px solid @dark-border;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    box-shadow: none;
 
     h5 a {
       color: @dark-text;
@@ -216,12 +246,15 @@
 
   // Tags
   .tags {
-    a, .tag {
+
+    a,
+    .tag {
       background-color: @dark-bg-secondary;
       border-color: @dark-border;
       color: @dark-text;
 
-      &:hover, &:active {
+      &:hover,
+      &:active {
         background-color: @dark-link;
         border-color: @dark-link;
         color: white !important;
@@ -230,27 +263,31 @@
   }
 
   // Horizontal rules
-  hr, hr.small {
+  hr,
+  hr.small {
     border-color: @dark-border;
   }
 
   // Tag listing separator
   .listing-seperator {
     color: @dark-link;
-    
+
     &:hover {
       color: @dark-link-hover;
     }
   }
 
   #tag_cloud {
-    a, .tag {
+
+    a,
+    .tag {
       background-color: @dark-bg-secondary !important;
       background: @dark-bg-secondary !important;
       color: @dark-text !important;
       border: 1px solid @dark-border !important;
 
-      &:hover, &:active {
+      &:hover,
+      &:active {
         background-color: @dark-link !important;
         background: @dark-link !important;
         color: white !important;
@@ -262,7 +299,9 @@
   // Pager
   .pager {
     li {
-      > a, > span {
+
+      >a,
+      >span {
         background-color: @dark-bg-secondary;
         border: 1px solid @dark-border;
         color: @dark-text;
@@ -272,7 +311,8 @@
         }
       }
 
-      > a:hover, > a:focus {
+      >a:hover,
+      >a:focus {
         background-color: @dark-link;
         border-color: @dark-link;
         color: white;
@@ -304,13 +344,29 @@
 
     .copyright {
       color: @dark-text-secondary;
-      
+
       a {
         color: @dark-link;
-        &:hover, &:focus {
+
+        &:hover,
+        &:focus {
           color: @dark-link-hover;
         }
       }
+    }
+  }
+
+  // Forms Styles
+  input,
+  textarea,
+  select {
+    background-color: @dark-bg-secondary;
+    color: @dark-text;
+    border-color: @dark-border;
+
+    &:focus {
+      background-color: @dark-bg-secondary;
+      border-color: @dark-link;
     }
   }
 
@@ -335,29 +391,17 @@
     }
   }
 
-  // Forms
-  input, textarea, select {
-    background-color: @dark-bg-secondary;
-    color: @dark-text;
-    border-color: @dark-border;
-
-    &:focus {
-      background-color: @dark-bg-secondary;
-      border-color: @dark-link;
-    }
-  }
-
   // Search bar
   #search-bar {
     background-color: @dark-bg-secondary !important;
     color: @dark-text !important;
     border-color: @dark-border !important;
-    
+
     &:focus {
       background-color: @dark-bg-secondary !important;
       color: @dark-text !important;
       border-color: @dark-link !important;
-      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
     }
   }
 
@@ -366,14 +410,14 @@
     background-color: @dark-bg-secondary;
     color: @dark-text;
     border-color: @dark-border;
-    
+
     &:focus {
       background-color: @dark-bg-secondary;
       color: @dark-text;
       border-color: @dark-link;
-      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(107, 181, 255, 0.6);
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(107, 181, 255, 0.6);
     }
-    
+
     &::placeholder {
       color: @dark-text-secondary;
     }
@@ -385,7 +429,8 @@
     border-color: @dark-border;
     color: @dark-text;
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       background-color: @dark-link;
       border-color: @dark-link;
       color: white;

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -1,0 +1,415 @@
+// Dark Mode Styles for Hibikilogy
+
+// Dark mode color variables
+@dark-bg: #1a1a1a;
+@dark-bg-secondary: #2d2d2d;
+@dark-text: #e0e0e0;
+@dark-text-secondary: #b0b0b0;
+@dark-border: #404040;
+@dark-link: #6eb5ff;
+@dark-link-hover: #9fd3ff;
+@dark-code-bg: #2d2d2d;
+@dark-blockquote-bg: #252525;
+
+// Dark mode styles
+[data-theme="dark"] {
+  
+  // Base styles
+  body {
+    background-color: @dark-bg;
+    color: @dark-text;
+  }
+
+  // Typography
+  h1, h2, h3, h4, h5, h6 {
+    color: @dark-text;
+  }
+
+  a {
+    color: @dark-link;
+    &:hover, &:focus {
+      color: @dark-link-hover;
+    }
+  }
+
+  // Navigation
+  .navbar-custom {
+    background-color: fade(@dark-bg-secondary, 95%);
+    border-bottom: 1px solid @dark-border;
+
+    &.is-fixed {
+      background-color: fade(@dark-bg-secondary, 95%);
+      border-bottom: 1px solid @dark-border;
+
+      .navbar-brand {
+        color: @dark-text;
+        &:hover, &:focus {
+          color: @dark-link;
+        }
+      }
+
+      .nav li a {
+        color: @dark-text;
+        &:hover, &:focus {
+          color: @dark-link;
+        }
+      }
+    }
+  }
+
+  @media only screen and (max-width: 767px) {
+    .navbar-default .navbar-collapse {
+      background: @dark-bg-secondary;
+      box-shadow: 0px 5px 10px 2px rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  // Header
+  .intro-header {
+    .post-heading, .page-heading, .site-heading {
+      h1, h2, .subheading, .meta {
+        text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+      }
+    }
+  }
+
+  // Post content
+  .post-container, .postlist-container {
+    color: @dark-text;
+
+    a {
+      color: @dark-link;
+      &:hover, &:focus {
+        color: @dark-link-hover;
+      }
+    }
+
+    h5, h6 {
+      color: @dark-text-secondary;
+    }
+
+    blockquote {
+      background-color: @dark-blockquote-bg;
+      border-left: 4px solid @dark-border;
+      color: @dark-text-secondary;
+    }
+
+    code {
+      background-color: @dark-code-bg;
+      color: #ff6b6b;
+      border: 1px solid @dark-border;
+    }
+
+    pre {
+      background-color: @dark-code-bg;
+      border: 1px solid @dark-border;
+      
+      code {
+        background-color: transparent;
+        border: none;
+      }
+    }
+
+    table {
+      th, td {
+        border: 1px solid @dark-border !important;
+        background-color: @dark-bg-secondary;
+      }
+      
+      thead th {
+        background-color: #3a3a3a;
+      }
+    }
+
+    img {
+      opacity: 0.9;
+      transition: opacity 0.3s ease;
+      
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
+
+  // Post preview
+  .post-preview {
+    > a {
+      color: @dark-text;
+      &:hover, &:focus {
+        color: @dark-link;
+      }
+    }
+
+    > .post-meta {
+      color: @dark-text-secondary;
+      
+      > a {
+        color: @dark-text-secondary;
+        &:hover, &:focus {
+          color: @dark-link;
+        }
+      }
+    }
+  }
+
+  .post-content-preview {
+    color: @dark-text-secondary;
+    &:hover {
+      color: @dark-link;
+    }
+  }
+
+  // Sidebar
+  .sidebar-container {
+    color: @dark-text;
+
+    h5 {
+      color: @dark-text;
+      
+      a {
+        color: @dark-text;
+        &:hover {
+          color: @dark-link;
+        }
+      }
+    }
+
+    .short-about {
+      color: @dark-text-secondary;
+    }
+  }
+
+  // Side catalog
+  .side-catalog {
+    background-color: @dark-bg;
+    border: 1px solid @dark-border;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+
+    h5 a {
+      color: @dark-text;
+    }
+
+    .catalog-body {
+      li {
+        a {
+          color: @dark-text-secondary;
+          border-left: 2px solid @dark-border;
+
+          &:hover {
+            color: @dark-link;
+            border-left-color: @dark-link;
+          }
+
+          &.active {
+            color: @dark-link;
+            border-left-color: @dark-link;
+          }
+        }
+      }
+    }
+  }
+
+  // Tags
+  .tags {
+    a, .tag {
+      background-color: @dark-bg-secondary;
+      border-color: @dark-border;
+      color: @dark-text;
+
+      &:hover, &:active {
+        background-color: @dark-link;
+        border-color: @dark-link;
+        color: white;
+      }
+    }
+  }
+
+  // Horizontal rules
+  hr, hr.small {
+    border-color: @dark-border;
+  }
+
+  // Tag listing separator
+  .listing-seperator {
+    color: @dark-link;
+    
+    &:hover {
+      color: @dark-link-hover;
+    }
+  }
+
+  #tag_cloud {
+    a, .tag {
+      background-color: @dark-bg-secondary !important;
+      background: @dark-bg-secondary !important;
+      color: @dark-text !important;
+      border: 1px solid @dark-border !important;
+
+      &:hover, &:active {
+        background-color: @dark-link !important;
+        background: @dark-link !important;
+        color: white !important;
+        border-color: @dark-link !important;
+      }
+    }
+  }
+
+  // Pager
+  .pager {
+    li {
+      > a, > span {
+        background-color: @dark-bg-secondary;
+        border: 1px solid @dark-border;
+        color: @dark-text;
+
+        span {
+          color: @dark-text-secondary;
+        }
+      }
+
+      > a:hover, > a:focus {
+        background-color: @dark-link;
+        border-color: @dark-link;
+        color: white;
+
+        span {
+          color: white;
+        }
+      }
+    }
+
+    .disabled > a,
+    .disabled > a:hover,
+    .disabled > a:focus,
+    .disabled > span {
+      background-color: #3a3a3a;
+      color: #666;
+    }
+  }
+
+  // Footer
+  footer {
+    background-color: @dark-bg-secondary;
+    border-top: 1px solid @dark-border;
+    color: @dark-text-secondary;
+
+    .copyright {
+      color: @dark-text-secondary;
+      
+      a {
+        color: @dark-link;
+        &:hover, &:focus {
+          color: @dark-link-hover;
+        }
+      }
+    }
+  }
+
+  // Comments (Gitalk)
+  #gitalk-container {
+    .gt-container {
+      .gt-header-textarea {
+        background-color: @dark-bg-secondary;
+        color: @dark-text;
+        border-color: @dark-border;
+      }
+
+      .gt-comment {
+        background-color: @dark-bg-secondary;
+        border-color: @dark-border;
+
+        .gt-comment-content {
+          background-color: @dark-bg-secondary;
+          color: @dark-text;
+        }
+      }
+    }
+  }
+
+  // Forms
+  input, textarea, select {
+    background-color: @dark-bg-secondary;
+    color: @dark-text;
+    border-color: @dark-border;
+
+    &:focus {
+      background-color: @dark-bg-secondary;
+      border-color: @dark-link;
+    }
+  }
+
+  // Search bar
+  #search-bar {
+    background-color: @dark-bg-secondary !important;
+    color: @dark-text !important;
+    border-color: @dark-border !important;
+    
+    &:focus {
+      background-color: @dark-bg-secondary !important;
+      color: @dark-text !important;
+      border-color: @dark-link !important;
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
+    }
+  }
+
+  // Form control
+  .form-control {
+    background-color: @dark-bg-secondary;
+    color: @dark-text;
+    border-color: @dark-border;
+    
+    &:focus {
+      background-color: @dark-bg-secondary;
+      color: @dark-text;
+      border-color: @dark-link;
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(107, 181, 255, 0.6);
+    }
+    
+    &::placeholder {
+      color: @dark-text-secondary;
+    }
+  }
+
+  // Buttons
+  .btn-default {
+    background-color: @dark-bg-secondary;
+    border-color: @dark-border;
+    color: @dark-text;
+
+    &:hover, &:focus {
+      background-color: @dark-link;
+      border-color: @dark-link;
+      color: white;
+    }
+  }
+
+  // Selection
+  ::selection {
+    background: @dark-link;
+    color: white;
+  }
+
+  ::-moz-selection {
+    background: @dark-link;
+    color: white;
+  }
+
+  // Scrollbar (Webkit)
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: @dark-bg;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: @dark-bg-secondary;
+    border-radius: 5px;
+
+    &:hover {
+      background: #4a4a4a;
+    }
+  }
+}

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -11,6 +11,10 @@
 @dark-code-bg: #2d2d2d;
 @dark-blockquote-bg: #252525;
 
+// Disabled state colors
+@dark-disabled-bg: #1f1f1f;
+@dark-disabled-text: #808080;
+
 // Dark mode styles
 [data-theme="dark"] {
 
@@ -322,9 +326,10 @@
       >a:hover,
       >a:focus,
       >span {
-        color: @dark-border;
-        background-color: @dark-bg;
-        cursor: not-allowed;
+        color: @dark-disabled-text !important;
+        background-color: @dark-disabled-bg !important;
+        cursor: not-allowed !important;
+        pointer-events: none !important;
       }
     }
   }
@@ -396,7 +401,7 @@
       border-color: @dark-link !important;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
     }
-    
+
     &:not(:focus) {
       color: @dark-text !important;
     }

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -137,6 +137,11 @@
       color: @dark-text;
       &:hover, &:focus {
         color: @dark-link;
+        text-decoration: none;
+        
+        > .post-title {
+          color: @dark-link;
+        }
       }
     }
 

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -286,6 +286,25 @@
     }
   }
 
+  // Tags in post heading (page top/footer) - use transparent background
+  .post-heading .tags,
+  .page-heading .tags,
+  .site-heading .tags {
+    a,
+    .tag {
+      background-color: transparent;
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      color: rgba(255, 255, 255, 0.9);
+
+      &:hover,
+      &:active {
+        background-color: rgba(255, 255, 255, 0.2);
+        border-color: rgba(255, 255, 255, 0.6);
+        color: white !important;
+      }
+    }
+  }
+
   // Horizontal rules
   hr,
   hr.small {

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -228,16 +228,13 @@
       li {
         a {
           color: @dark-text-secondary;
-          border-left: 2px solid @dark-border;
 
           &:hover {
             color: @dark-link;
-            border-left-color: @dark-link;
           }
 
           &.active {
             color: @dark-link;
-            border-left-color: @dark-link;
           }
         }
       }

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -278,12 +278,16 @@
       }
     }
 
-    .disabled > a,
-    .disabled > a:hover,
-    .disabled > a:focus,
-    .disabled > span {
-      background-color: #3a3a3a;
-      color: #666;
+    .disabled {
+
+      >a,
+      >a:hover,
+      >a:focus,
+      >span {
+        color: @dark-border;
+        background-color: @dark-bg;
+        cursor: not-allowed;
+      }
     }
   }
 

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -18,6 +18,7 @@
 @tagcloud-light-color: @dark-tagcloud-light-color;
 @tagcloud-dark-color: @dark-tagcloud-dark-color;
 @accent-color: @dark-accent-color;
+@catalog-active-bg: @dark-catalog-active-bg;
 
 // Dark mode styles
 [data-theme="dark"] {
@@ -254,7 +255,7 @@
         }
         
         &.active {
-          background-color: @bg-secondary;
+          background-color: @catalog-active-bg;
           border-radius: 4px;
         }
       }

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -31,7 +31,7 @@
     // Tag cloud gradient colors (CSS variables for dark mode)
     --tagcloud-light-color: @dark-tagcloud-light-color;
     --tagcloud-dark-color: @dark-tagcloud-dark-color;
-    
+
     // Accent color for dark mode
     --accent-color: @dark-accent-color;
   }
@@ -182,7 +182,8 @@
         color: @link;
         text-decoration: none;
 
-        >.post-title {
+        >.post-title,
+        >.post-subtitle {
           color: @link;
         }
       }
@@ -253,7 +254,7 @@
             color: @accent-color;
           }
         }
-        
+
         &.active {
           background-color: @catalog-active-bg;
           border-radius: 4px;
@@ -419,7 +420,7 @@
       border-color: @link !important;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(107, 181, 255, 0.6) !important;
     }
-    
+
     &:not(:focus) {
       color: @text !important;
     }

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -219,7 +219,7 @@
       &:hover, &:active {
         background-color: @dark-link;
         border-color: @dark-link;
-        color: white;
+        color: white !important;
       }
     }
   }

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -281,15 +281,11 @@
 
     a,
     .tag {
-      background-color: @dark-bg-secondary !important;
-      background: @dark-bg-secondary !important;
       color: @dark-text !important;
       border: 1px solid @dark-border !important;
 
       &:hover,
       &:active {
-        background-color: @dark-link !important;
-        background: @dark-link !important;
         color: white !important;
         border-color: @dark-link !important;
       }

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -48,6 +48,12 @@
 
   a {
     color: @link;
+    transition: all 0.4s ease;
+    -moz-transition: all 0.4s ease;
+    /* Firefox 4 */
+    -webkit-transition: all 0.4s ease;
+    /* Safari 和 Chrome */
+    -o-transition: all 0.4s ease;
 
     &:hover,
     &:focus {
@@ -175,7 +181,6 @@
   .post-preview {
     >a {
       color: @text;
-      transition: all 0.4s ease;
 
       &:hover,
       &:focus {

--- a/less/dark-mode.less
+++ b/less/dark-mode.less
@@ -282,12 +282,12 @@
     a,
     .tag {
       color: @dark-text !important;
-      border: 1px solid @dark-border !important;
+      border: none !important;
 
       &:hover,
       &:active {
         color: white !important;
-        border-color: @dark-link !important;
+        border: none !important;
       }
     }
   }

--- a/less/hux-blog.less
+++ b/less/hux-blog.less
@@ -12,7 +12,7 @@ body {
 	// Hux mpdify to 16px (Mobile First), and increase to 20px while 768+ width
 	color: @gray-dark;
 	//-webkit-user-select:text; //对于 Blog 还是先不开启这句。
-	overflow-x : hidden;
+	overflow-x: hidden;
 }
 
 // -- Typography
@@ -31,19 +31,26 @@ h6 {
 	line-height: 1.1;
 	font-weight: bold;
 }
-h1{
+
+h1 {
 	// drop V1.1.1
 	//font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
-h4{
-    font-size: 21px;
+
+h4 {
+	font-size: 21px;
 }
+
 a {
 	color: @gray-dark;
 	transition: all 0.4s ease;
-    -moz-transition: all 0.4s ease;  /* Firefox 4 */
-    -webkit-transition: all 0.4s ease;  /* Safari 和 Chrome */
-    -o-transition: all 0.4s ease;  /* Opera */
+	-moz-transition: all 0.4s ease;
+	/* Firefox 4 */
+	-webkit-transition: all 0.4s ease;
+	/* Safari 和 Chrome */
+	-o-transition: all 0.4s ease;
+
+	/* Opera */
 	&:hover,
 	&:focus {
 		color: @brand-primary;
@@ -51,15 +58,16 @@ a {
 }
 
 a img {
+
 	&:hover,
 	&:focus {
 		cursor: zoom-in;
 	}
 }
 
-article{
+article {
 	word-wrap: break-word;
-    word-break: normal;
+	word-break: normal;
 }
 
 blockquote {
@@ -67,42 +75,48 @@ blockquote {
 	/* font-style: italic; */
 	font-size: 0.95em;
 	margin: 20px 0 20px;
-	p{
+
+	p {
 		margin: 0;
 	}
 }
 
 // Utils Style Class can be used in Markdown.
-small.img-hint{
+small.img-hint {
 	display: block;
 	margin-top: -20px;
 	text-align: center;
 }
-br + small.img-hint{
+
+br+small.img-hint {
 	margin-top: -40px;
 }
-img.shadow{
+
+img.shadow {
 	box-shadow: rgba(0, 0, 0, 0.258824) 0px 2px 5px 0px;
 }
+
 // Utils Style End
 
 // Select 
-select{
-	-webkit-appearance:none;
-	margin-top:15px;
-	color:#337ab7;
-	border-color:#337ab7;
+select {
+	-webkit-appearance: none;
+	margin-top: 15px;
+	color: #337ab7;
+	border-color: #337ab7;
 	padding: 0em 0.4em;
 	background: white;
-	&.sel-lang{
+
+	&.sel-lang {
 		min-height: 28px;
-		font-size:14px;
+		font-size: 14px;
 	}
 }
 
 
 // override table style in bootstrap
-.table th, .table td{
+.table th,
+.table td {
 	border: 1px solid #eee !important;
 }
 
@@ -112,39 +126,44 @@ hr.small {
 	border-width: 4px;
 	border-color: white;
 }
+
 // add by Hux
-pre,.table-responsive{
+pre,
+.table-responsive {
 	// sometimes you should use vendor-feature.
 	-webkit-overflow-scrolling: touch;
 }
-pre code{
+
+pre code {
 	display: block;
 	width: auto;
-	white-space: pre;	// save it but no-wrap;
-	word-wrap: normal;	// no-wrap
+	white-space: pre; // save it but no-wrap;
+	word-wrap: normal; // no-wrap
 }
 
 // In the list of posts
-.postlist-container{
+.postlist-container {
 	margin-bottom: 15px;
 }
 
-.about-container{
-	a{
-		color:#337ab7;
+.about-container {
+	a {
+		color: #337ab7;
 	}
 }
 
 // In the post.
-.post-container{
-	a{
-		color:#337ab7;
+.post-container {
+	a {
+		color: #337ab7;
+
 		// different to @brand-primary
 		&:hover,
 		&:focus {
 			color: @brand-primary;
 		}
 	}
+
 	h1,
 	h2,
 	h3,
@@ -153,56 +172,88 @@ pre code{
 	h6 {
 		margin: 30px 0 10px;
 	}
-	h5{
+
+	h5 {
 		font-size: 19px;
 		font-weight: 600;
-		color:gray;
-		& + p{
+		color: gray;
+
+		&+p {
 			margin-top: 5px;
 		}
 	}
-	h6{
+
+	h6 {
 		font-size: 16px;
 		font-weight: 600;
 		color: gray;
-		& + p{
+
+		&+p {
 			margin-top: 5px;
 		}
 	}
-	ul,ol{
+
+	ul,
+	ol {
 		margin-bottom: 40px;
-		@media screen and (max-width: 768px){
-			&{
+
+		@media screen and (max-width: 768px) {
+			& {
 				padding-left: 30px;
 			}
 		}
-		@media screen and (max-width: 500px){
-			&{
+
+		@media screen and (max-width: 500px) {
+			& {
 				padding-left: 20px;
 			}
 		}
 	}
-	ol ol, ol ul, ul ol, ul ul{
+
+	ol ol,
+	ol ul,
+	ul ol,
+	ul ul {
 		margin-bottom: 5px
 	}
-	li{
-		p{
+
+	li {
+		p {
 			margin: 0;
 			margin-bottom: 5px;
 		}
-		h1,h2,h3,h4,h5,h6{
+
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
 			line-height: 2;
 			margin-top: 20px;
 		}
 	}
+
 	// V1.6 Hux display title by default.
-	.pager li{
+	.pager li {
 		width: 48%;
-		&.next{ float: right};
-		&.previous{ float: left};
-		> a {
+
+		&.next {
+			float: right
+		}
+
+		;
+
+		&.previous {
+			float: left
+		}
+
+		;
+
+		>a {
 			width: 100%;
-			> span{
+
+			>span {
 				color: @gray;
 				font-weight: normal;
 				letter-spacing: 0.5px;
@@ -217,14 +268,15 @@ pre code{
 
 // materialize, mobile only
 @media only screen and (max-width: 767px) {
+
 	/**
 	 * Layout
 	 * Since V1.6 we use absolute positioning to prevent to expand container-fluid
 	 * which would cover tags. A absolute positioning make a new layer.
 	 */
-	.navbar-default .navbar-collapse{
-		position: absolute; 
-     	right: 0;
+	.navbar-default .navbar-collapse {
+		position: absolute;
+		right: 0;
 		border: none;
 		background: white;
 		box-shadow: 0px 5px 10px 2px rgba(0, 0, 0, 0.2);
@@ -232,11 +284,12 @@ pre code{
 		border-radius: 2px;
 		width: 170px;
 	}
+
 	/**
 	 * Animation
 	 * HuxBlog-Navbar using genuine Material Design Animation
 	 */
-	#huxblog_navbar{ 	
+	#huxblog_navbar {
 		/**
 		 * Sharable code and 'out' function
 		 */
@@ -248,12 +301,15 @@ pre code{
 		-webkit-transform: scaleX(0);
 		-webkit-transform-origin: top right;
 		-webkit-transition: all 200ms cubic-bezier(0.47, 0, 0.4, 0.99) 0ms;
+
 		a {
 			font-size: 13px;
 			line-height: 28px;
 		}
-		.navbar-collapse{	// the navbar do height-transition
-			height: 0px; 	// to solve container-mask-tags issue (default state).
+
+		.navbar-collapse {
+			// the navbar do height-transition
+			height: 0px; // to solve container-mask-tags issue (default state).
 			transform: scaleY(0);
 			transform-origin: top right;
 			transition: transform 400ms cubic-bezier(0.32, 1, 0.23, 1) 0ms;
@@ -261,11 +317,13 @@ pre code{
 			-webkit-transform-origin: top right;
 			-webkit-transition: -webkit-transform 400ms cubic-bezier(0.32, 1, 0.23, 1) 0ms;
 		}
-		li{
+
+		li {
 			opacity: 0;
 			transition: opacity 100ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 			-webkit-transition: opacity 100ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 		}
+
 		/**
 		 *'In' Animation
 		 */
@@ -273,15 +331,17 @@ pre code{
 			transform: scaleX(1);
 			-webkit-transform: scaleX(1);
 			opacity: 1;
-			transition: all 250ms cubic-bezier(0.23,1,0.32,1) 0ms;
-			-webkit-transition: all 250ms cubic-bezier(0.23,1,0.32,1) 0ms;
-			.navbar-collapse{
+			transition: all 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+			-webkit-transition: all 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+
+			.navbar-collapse {
 				transform: scaleY(1);
 				-webkit-transform: scaleY(1);
 				transition: transform 500ms cubic-bezier(0.23, 1, 0.32, 1);
 				-webkit-transition: -webkit-transform 500ms cubic-bezier(0.23, 1, 0.32, 1);
 			}
-			li{
+
+			li {
 				opacity: 1;
 				transition: opacity 450ms cubic-bezier(0.23, 1, 0.32, 1) 205ms;
 				-webkit-transition: opacity 450ms cubic-bezier(0.23, 1, 0.32, 1) 205ms;
@@ -293,23 +353,26 @@ pre code{
 .navbar-custom {
 	// materialize
 	background: none;
-	border:none;
+	border: none;
 	position: absolute;
 	top: 0;
 	left: 0;
 	width: 100%;
 	z-index: 3;
 	.sans-serif;
+
 	.navbar-brand {
 		font-weight: 800;
 		// materialize
 		color: white;
 		height: 56px;
 		line-height: 25px;
-		&:hover{
+
+		&:hover {
 			color: rgba(255, 255, 255, 0.8);
 		}
 	}
+
 	.nav {
 		li {
 			a {
@@ -318,44 +381,53 @@ pre code{
 				line-height: 20px;
 				font-weight: 800;
 				letter-spacing: 1px;
+
 				// only highlight in mobile
-				&:active{
-					background: rgba(0,0,0,0.12)
+				&:active {
+					background: rgba(0, 0, 0, 0.12)
 				}
 			}
 		}
 	}
+
 	@media only screen and (min-width: 768px) {
-		body{
+		body {
 			font-size: 20px;
 		}
+
 		background: transparent;
 		border-bottom: 1px solid transparent;
+
 		.navbar-brand {
 			color: white;
 			padding: 20px;
 			line-height: 20px;
+
 			&:hover,
 			&:focus {
 				color: @white-faded;
 			}
 		}
+
 		.nav {
 			li {
 				a {
 					color: white;
 					padding: 20px;
+
 					&:hover,
 					&:focus {
 						color: @white-faded;
 					}
-					&:active{
+
+					&:active {
 						background: none;
 					}
 				}
 			}
 		}
 	}
+
 	@media only screen and (min-width: 1170px) {
 		-webkit-transition: background-color 0.3s;
 		-moz-transition: background-color 0.3s;
@@ -368,6 +440,7 @@ pre code{
 		transform: translate3d(0, 0, 0);
 		-webkit-backface-visibility: hidden;
 		backface-visibility: hidden;
+
 		&.is-fixed {
 			/* when the user scrolls down, we hide the header right above the viewport */
 			position: fixed;
@@ -377,17 +450,21 @@ pre code{
 			-webkit-transition: -webkit-transform 0.3s;
 			-moz-transition: -moz-transform 0.3s;
 			transition: transform 0.3s;
+
 			.navbar-brand {
 				color: @gray-dark;
+
 				&:hover,
 				&:focus {
 					color: @brand-primary;
 				}
 			}
+
 			.nav {
 				li {
 					a {
 						color: @gray-dark;
+
 						&:hover,
 						&:focus {
 							color: @brand-primary;
@@ -396,6 +473,7 @@ pre code{
 				}
 			}
 		}
+
 		&.is-visible {
 			/* if the user changes the scrolling direction, we show the header */
 			-webkit-transform: translate3d(0, 100%, 0);
@@ -415,33 +493,43 @@ pre code{
 	background-attachment: scroll;
 	.background-cover;
 	// NOTE: Background images are set within the HTML using inline CSS!
-	margin-bottom: 0px;  /* 0 on mobile, modify by Hux */
+	margin-bottom: 0px;
+
+	/* 0 on mobile, modify by Hux */
 	@media only screen and (min-width: 768px) {
-		margin-bottom: 20px;  /* response on desktop */
+		margin-bottom: 20px;
+		/* response on desktop */
 	}
+
 	.site-heading,
 	.post-heading,
 	.page-heading {
 		padding: 85px 0 55px;
 		color: white;
+
 		@media only screen and (min-width: 768px) {
 			padding: 150px 0;
 		}
 	}
+
 	// masterialize
-	.site-heading{
+	.site-heading {
 		padding: 95px 0 70px;
+
 		@media only screen and (min-width: 768px) {
 			padding: 150px 0;
 		}
 	}
+
 	.site-heading,
 	.page-heading {
 		text-align: center;
+
 		h1 {
 			margin-top: 0;
 			font-size: 50px;
 		}
+
 		.subheading {
 			.sans-serif;
 			font-size: 18px;
@@ -450,22 +538,26 @@ pre code{
 			font-weight: 300;
 			margin: 10px 0 0;
 		}
+
 		@media only screen and (min-width: 768px) {
 			h1 {
 				font-size: 80px;
 			}
 		}
 	}
+
 	.post-heading {
 		h1 {
 			font-size: 30px;
 			margin-bottom: 24px;
 		}
+
 		.subheading,
 		.meta {
 			line-height: 1.1;
 			display: block;
 		}
+
 		.subheading {
 			.sans-serif;
 			font-size: 17px;
@@ -474,22 +566,27 @@ pre code{
 			margin: 10px 0 30px;
 			margin-top: -5px;
 		}
+
 		.meta {
 			.serif;
 			/* font-style: italic; */
 			font-weight: 300;
 			font-size: 18px;
+
 			a {
 				color: white;
 			}
 		}
+
 		@media only screen and (min-width: 768px) {
 			h1 {
 				font-size: 55px;
 			}
+
 			.subheading {
 				font-size: 30px;
 			}
+
 			.meta {
 				font-size: 20px;
 			}
@@ -500,20 +597,23 @@ pre code{
 // Post Preview Pages (Home Page)
 
 .post-preview {
-	> a {
+	>a {
 		color: @gray-dark;
+
 		&:hover,
 		&:focus {
 			text-decoration: none;
 			color: @brand-primary;
 		}
-		> .post-title {
+
+		>.post-title {
 			font-size: 21px;
 			line-height: 1.3;
 			margin-top: 30px;
 			margin-bottom: 8px;
 		}
-		> .post-subtitle {
+
+		>.post-subtitle {
 			font-size: 15px;
 			line-height: 1.3;
 			margin: 0;
@@ -521,15 +621,18 @@ pre code{
 			margin-bottom: 10px;
 		}
 	}
-	> .post-meta {
+
+	>.post-meta {
 		.serif;
 		color: @gray;
 		font-size: 16px;
 		/* font-style: italic; */
 		margin-top: 0;
-		> a {
+
+		>a {
 			text-decoration: none;
 			color: @gray-dark;
+
 			&:hover,
 			&:focus {
 				color: @brand-primary;
@@ -537,33 +640,38 @@ pre code{
 			}
 		}
 	}
+
 	@media only screen and (min-width: 768px) {
-		> a {
-			> .post-title {
+		>a {
+			>.post-title {
 				font-size: 26px;
 				line-height: 1.3;
 				margin-bottom: 10px;
 			}
-			> .post-subtitle{
+
+			>.post-subtitle {
 				font-size: 16px;
 			}
 		}
-		.post-meta{
+
+		.post-meta {
 			font-size: 18px;
 		}
 	}
 }
 
 // Hux add home-page post-content-preview
-.post-content-preview{
-    font-size: 13px;
-    color:#a3a3a3;
-    &:hover{
-        color: @brand-primary;
-    }
-    @media only screen and (min-width: 768px) {
-        font-size:14px;
-    }
+.post-content-preview {
+	font-size: 13px;
+	color: #a3a3a3;
+
+	&:hover {
+		color: @brand-primary;
+	}
+
+	@media only screen and (min-width: 768px) {
+		font-size: 14px;
+	}
 }
 
 // Sections
@@ -588,16 +696,20 @@ pre code{
 footer {
 	font-size: 20px;
 	padding: 50px 0 65px;
+
 	.list-inline {
 		margin: 0;
 		padding: 0;
 	}
+
 	.copyright {
 		font-size: 14px;
 		text-align: center;
 		margin-bottom: 0;
-		a{
-			color:#337ab7;
+
+		a {
+			color: #337ab7;
+
 			// different to @brand-primary
 			&:hover,
 			&:focus {
@@ -615,6 +727,7 @@ footer {
 	margin-bottom: 0;
 	padding-bottom: 0.5em;
 	border-bottom: 1px solid @gray-light;
+
 	input,
 	textarea {
 		z-index: 1;
@@ -628,6 +741,7 @@ footer {
 		box-shadow: none !important;
 		resize: none;
 	}
+
 	label {
 		display: block;
 		z-index: 0;
@@ -639,11 +753,12 @@ footer {
 		vertical-align: middle;
 		vertical-align: baseline;
 		opacity: 0;
-		-webkit-transition: top 0.3s ease,opacity 0.3s ease;
-		-moz-transition: top 0.3s ease,opacity 0.3s ease;
-		-ms-transition: top 0.3s ease,opacity 0.3s ease;
-		transition: top 0.3s ease,opacity 0.3s ease;
+		-webkit-transition: top 0.3s ease, opacity 0.3s ease;
+		-moz-transition: top 0.3s ease, opacity 0.3s ease;
+		-ms-transition: top 0.3s ease, opacity 0.3s ease;
+		transition: top 0.3s ease, opacity 0.3s ease;
 	}
+
 	&::not(:first-child) {
 		padding-left: 14px;
 		border-left: 1px solid @gray-light;
@@ -685,6 +800,7 @@ form .row:first-child .floating-label-form-group {
 }
 
 .btn-default {
+
 	&:hover,
 	&:focus {
 		background-color: @brand-primary;
@@ -697,11 +813,12 @@ form .row:first-child .floating-label-form-group {
 
 .pager {
 	margin: 20px 0 0 !important;
-	padding:0px !important;
+	padding: 0px !important;
 
 	li {
-		> a,
-		> span {
+
+		>a,
+		>span {
 			.sans-serif;
 			text-transform: uppercase;
 			font-size: 13px;
@@ -710,33 +827,36 @@ form .row:first-child .floating-label-form-group {
 			padding: 10px;
 			background-color: white;
 			border-radius: 0;
+
 			@media only screen and (min-width: 768px) {
 				font-size: 14px;
 				padding: 15px 25px;
 			}
 		}
 
-		> a {
+		>a {
 			color: @gray-dark;
 		}
-		> a:hover,
-		> a:focus {
+
+		>a:hover,
+		>a:focus {
 			color: white;
 			background-color: @brand-primary;
 			border: 1px solid @brand-primary;
 
 			// V1.6 display title
-			> span{
+			>span {
 				color: white;
 			}
 		}
 	}
 
 	.disabled {
-		> a,
-		> a:hover,
-		> a:focus,
-		> span {
+
+		>a,
+		>a:hover,
+		>a:focus,
+		>span {
 			color: @gray;
 			background-color: @gray-dark;
 			cursor: not-allowed;
@@ -768,80 +888,98 @@ img::-moz-selection {
 
 
 /* Hux add tags support */
-.tags{
+.tags {
 	margin-bottom: -5px;
-	a,.tag{
+
+	a,
+	.tag {
 		display: inline-block;
-		border: 1px solid rgba(255,255,255,0.8);
+		border: 1px solid rgba(255, 255, 255, 0.8);
 		border-radius: 999em;
 		padding: 0 10px;
-		color: rgba(255,255,255,1);
+		color: rgba(255, 255, 255, 1);
 		line-height: 24px;
 		font-size: 12px;
 		text-decoration: none;
 		margin: 0 1px;
 		margin-bottom: 6px;
-		&:hover, &:active{
-			color:white;
+
+		&:hover,
+		&:active {
+			color: white;
 			border-color: white;
-			background-color: rgba(255,255,255,0.4);
+			background-color: rgba(255, 255, 255, 0.4);
 			text-decoration: none;
 
 		}
+
 		@media only screen and (min-width: 768px) {
 			margin-right: 5px;
 		}
 	}
 }
 
-#tag-heading{
+#tag-heading {
 	padding: 70px 0 60px;
+
 	@media only screen and (min-width: 768px) {
-		padding:55px 0;
+		padding: 55px 0;
 	}
 
 }
+
 // tag_cloud
-#tag_cloud{
-	margin:20px 0 15px 0;
-	a,.tag{
+#tag_cloud {
+	margin: 20px 0 15px 0;
+
+	a,
+	.tag {
 		font-size: 14px;
 		border: none;
 		line-height: 28px;
 		margin: 0 2px;
 		margin-bottom: 8px;
 		background: #D6D6D6;
-		&:hover, &:active{
+
+		&:hover,
+		&:active {
 			background-color: #0085a1 !important;
 		}
 	}
+
 	@media only screen and (min-width: 768px) {
 		margin-bottom: 25px;
 	}
 }
 
-.tag-comments{
-    font-size: 12px;
-    	@media only screen and (min-width: 768px) {
-		font-size:14px;
+.tag-comments {
+	font-size: 12px;
+
+	@media only screen and (min-width: 768px) {
+		font-size: 14px;
 	}
 }
 
-.t{
+.t {
+
 	//margin-top: 50px;
-	&:first-child{
+	&:first-child {
 		margin-top: 0px;
 	}
-	hr:last-of-type{
+
+	hr:last-of-type {
 		//display: none;
 	}
 }
-.listing-seperator{
-	color:#0085a1;
+
+.listing-seperator {
+	color: #0085a1;
 	font-size: 21px !important;
-	&::before{
+
+	&::before {
 		margin-right: 5px;
 	}
+
 	@media only screen and (min-width: 768px) {
 		font-size: 20px !important;
 		line-height: 2 !important;
@@ -849,24 +987,28 @@ img::-moz-selection {
 }
 
 // Customize Style for Posts in One-Tag-List
-.one-tag-list{
-	.tag-text{
+.one-tag-list {
+	.tag-text {
 		font-weight: 200;
 		.sans-serif;
 	}
+
 	.post-preview {
 		position: relative;
-		> a {
-			.post-title{
+
+		>a {
+			.post-title {
 				font-size: 16px;
 				font-weight: 500;
 				margin-top: 20px;
 			}
-			.post-subtitle{
+
+			.post-subtitle {
 				font-size: 12px;
 			}
 		}
-		> .post-meta{
+
+		>.post-meta {
 			position: absolute;
 			right: 5px;
 			bottom: 0px;
@@ -874,18 +1016,22 @@ img::-moz-selection {
 			font-size: 12px;
 			line-height: 12px;
 		}
+
 		@media only screen and (min-width: 768px) {
 			margin-left: 20px;
-			> a {
-				> .post-title {
+
+			>a {
+				>.post-title {
 					font-size: 18px;
 					line-height: 1.3
 				}
-				> .post-subtitle{
+
+				>.post-subtitle {
 					font-size: 14px;
 				}
 			}
-			.post-meta{
+
+			.post-meta {
 				font-size: 18px;
 			}
 		}
@@ -895,7 +1041,7 @@ img::-moz-selection {
 /* Tags support End*/
 
 /* Hux make all img responsible in post-container */
-.post-container img{
+.post-container img {
 	display: block;
 	max-width: 100%;
 	height: auto;
@@ -905,81 +1051,94 @@ img::-moz-selection {
 
 /* Hux Optimize UserExperience */
 .navbar-default .navbar-toggle {
-	&:focus, &:hover{
+
+	&:focus,
+	&:hover {
 		background-color: inherit;
 	}
-  	&:active{
-  		background-color: rgba(255, 255, 255, 0.25);
-  	}
+
+	&:active {
+		background-color: rgba(255, 255, 255, 0.25);
+	}
 }
 
 /* Hux customize Style for navBar button */
 
-.navbar-default .navbar-toggle{
+.navbar-default .navbar-toggle {
 	border-color: transparent;
-	padding:19px 16px;
+	padding: 19px 16px;
 	margin-top: 2px;
 	margin-right: 2px;
 	margin-bottom: 2px;
 	border-radius: 50%;
-	.icon-bar{
+
+	.icon-bar {
 		width: 18px;
 		border-radius: 0px;
 		// materialize
 		background-color: white;
 	}
-	.icon-bar+.icon-bar{
+
+	.icon-bar+.icon-bar {
 		margin-top: 3px;
 	}
 }
 
 
 /* Hux customize Style for Duoshuo */
-.comment{
+.comment {
 	margin-top: 20px;
+
 	#ds-thread {
 		#ds-reset {
-			a.ds-like-thread-button{
-				border:1px solid #ddd;
+			a.ds-like-thread-button {
+				border: 1px solid #ddd;
 				border-radius: 0px;
 				background: white;
 				box-shadow: none;
 				text-shadow: none;
 			}
-			a.ds-thread-liked{
 
-			}
-			li.ds-tab a.ds-current{
-				border:1px solid #ddd;
+			a.ds-thread-liked {}
+
+			li.ds-tab a.ds-current {
+				border: 1px solid #ddd;
 				border-radius: 0px;
 				background: white;
 				box-shadow: none;
 				text-shadow: none;
 			}
-			.ds-textarea-wrapper{
+
+			.ds-textarea-wrapper {
 				//border:1px solid #ddd;
 				background: none;
 			}
-			.ds-gradient-bg{
+
+			.ds-gradient-bg {
 				background: none;
 			}
-			.ds-post-options{
+
+			.ds-post-options {
 				border-bottom: 1px solid #ccc;
 			}
-			.ds-post-button{
+
+			.ds-post-button {
 				border-bottom: 1px solid #ccc;
 			}
+
 			//v1.6 flatten button
-			.ds-post-button{
+			.ds-post-button {
 				background: white;
 				box-shadow: none;
-				&:hover{
+
+				&:hover {
 					background: @gray-light;
 				}
 			}
 		}
 	}
 }
+
 #ds-smilies-tooltip ul.ds-smilies-tabs li a {
 	background: white !important;
 }
@@ -987,14 +1146,15 @@ img::-moz-selection {
 
 // Hux fullscreen mode in 404.html
 
-.page-fullscreen .intro-header{
+.page-fullscreen .intro-header {
 	position: fixed;
 	left: 0;
 	top: 0;
 	width: 100%;
 	height: 100%;
 }
-.page-fullscreen #tag-heading{
+
+.page-fullscreen #tag-heading {
 	position: fixed;
 	left: 0;
 	top: 0;
@@ -1016,7 +1176,8 @@ img::-moz-selection {
 	justify-content: center;
 	flex-direction: column;
 }
-.page-fullscreen footer{
+
+.page-fullscreen footer {
 	position: absolute;
 	width: 100%;
 	bottom: 0;
@@ -1024,15 +1185,15 @@ img::-moz-selection {
 	opacity: 0.6;
 	color: #fff;
 }
-.page-fullscreen footer .copyright{
+
+.page-fullscreen footer .copyright {
 	color: #fff;
 }
-.page-fullscreen footer .copyright a{
+
+.page-fullscreen footer .copyright a {
 	color: #fff;
 }
-.page-fullscreen footer .copyright a:hover{
+
+.page-fullscreen footer .copyright a:hover {
 	color: #ddd;
 }
-
-
-

--- a/less/hux-blog.less
+++ b/less/hux-blog.less
@@ -858,8 +858,9 @@ form .row:first-child .floating-label-form-group {
 		>a:focus,
 		>span {
 			color: @gray;
-			background-color: @gray-dark;
+			background-color: @disabled-bg;
 			cursor: not-allowed;
+			pointer-events: none;
 		}
 	}
 }
@@ -939,11 +940,10 @@ img::-moz-selection {
 		line-height: 28px;
 		margin: 0 2px;
 		margin-bottom: 8px;
-		background: #D6D6D6;
 
 		&:hover,
 		&:active {
-			background-color: #0085a1 !important;
+			// background-color will be set by tagcloud.js
 		}
 	}
 

--- a/less/hux-blog.less
+++ b/less/hux-blog.less
@@ -2,6 +2,7 @@
 @import "mixins.less";
 @import "sidebar.less";
 @import "side-catalog.less";
+@import "dark-mode.less";
 
 // Global Components
 

--- a/less/hux-blog.less
+++ b/less/hux-blog.less
@@ -13,6 +13,13 @@ body {
 	color: @gray-dark;
 	//-webkit-user-select:text; //对于 Blog 还是先不开启这句。
 	overflow-x: hidden;
+
+	// Tag cloud gradient colors (CSS variables for light mode)
+	--tagcloud-light-color: @light-tagcloud-light-color;
+	--tagcloud-dark-color: @light-tagcloud-dark-color;
+	
+	// Accent color for light mode
+	--accent-color: @light-accent-color;
 }
 
 // -- Typography
@@ -973,7 +980,7 @@ img::-moz-selection {
 }
 
 .listing-seperator {
-	color: #0085a1;
+	color: @accent-color;
 	font-size: 21px !important;
 
 	&::before {

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -18,35 +18,25 @@
 }
 
 .sans-serif () {
-	/* Hux learn from
-     *     TypeIsBeautiful,
-     *     [This Post](http://zhuanlan.zhihu.com/ibuick/20186806) etc.
-     */
 	font-family:
-        // System Font            // https://www.webkit.org/blog/3709/using-the-system-font-in-web-content/
-        -apple-system,            // OSX ^10.11 & iOS ^9  San Francisco & 苹方 for Safari
-        BlinkMacSystemFont,       // OSX ^10.11 & iOS ^9  San Francisco & 苹方 for Blink 
-
-        // English First
-        "Helvetica Neue",         // OSX
-        "Arial",                  // Win "Helvetica"
-        //" Segoe UI",            // Win ^8
-
-        // Chinese Fallback
-        "PingFang SC",            // OSX ^10.11 & iOS ^9  苹方（华康信凭黑）
-        "Hiragino Sans GB",       // OSX ^10.6            冬青黑体
-        "STHeiti",                // OSX <10.6  & iOS <9  华文黑体
-        "Microsoft YaHei",        // Win                  微软雅黑
-        "Microsoft JhengHei",     // Win                  微软正黑
-        "Source Han Sans SC",     // SourceHan - begin    思源黑体
+        -apple-system,
+        BlinkMacSystemFont,
+        "Helvetica Neue",
+        "Arial",
+        "PingFang SC",
+        "Hiragino Sans GB",
+        "STHeiti",
+        "Microsoft YaHei",
+        "Microsoft JhengHei",
+        "Source Han Sans SC",
         "Noto Sans CJK SC",
         "Source Han Sans CN",
         "Noto Sans SC",
         "Source Han Sans TC",
-        "Noto Sans CJK TC",       // SourceHan - end
-        "WenQuanYi Micro Hei",    // Linux                文泉驿微米黑
-        SimSun,                   // Win old              中易宋体
-        sans-serif;               // System Fallback
+        "Noto Sans CJK TC",
+        "WenQuanYi Micro Hei",
+        SimSun,
+        sans-serif;
 
 	line-height: 1.7;
 }

--- a/less/side-catalog.less
+++ b/less/side-catalog.less
@@ -66,7 +66,7 @@
         }
         .active{
             a{
-                color: #0085a1!important;
+                color: @accent-color!important;
             }
             border-radius: 4px;
             background-color: #F5F5F5;

--- a/less/side-catalog.less
+++ b/less/side-catalog.less
@@ -69,7 +69,7 @@
                 color: @accent-color!important;
             }
             border-radius: 4px;
-            background-color: #F5F5F5;
+            background-color: @catalog-active-bg;
         }
     }
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -6,3 +6,6 @@
 @gray-l: lighten(black, 75%);
 @white-faded: fade(white, 80%);
 @gray-light: #eee;
+
+// Disabled state colors
+@disabled-bg: #ccd0d3;

--- a/less/variables.less
+++ b/less/variables.less
@@ -1,5 +1,7 @@
 // Variables
 
+@import "colors.less";
+
 @brand-primary: #33ADFF;
 @gray-dark: lighten(black, 25%);
 @gray: lighten(black, 50%);
@@ -7,5 +9,18 @@
 @white-faded: fade(white, 80%);
 @gray-light: #eee;
 
-// Disabled state colors
-@disabled-bg: #ccd0d3;
+// Default to light mode colors
+@bg: @light-bg;
+@bg-secondary: @light-bg-secondary;
+@text: @light-text;
+@text-secondary: @light-text-secondary;
+@border: @light-border;
+@link: @light-link;
+@link-hover: @light-link-hover;
+@code-bg: @light-code-bg;
+@blockquote-bg: @light-blockquote-bg;
+@disabled-bg: @light-disabled-bg;
+@disabled-text: @light-disabled-text;
+@tagcloud-light-color: @light-tagcloud-light-color;
+@tagcloud-dark-color: @light-tagcloud-dark-color;
+@accent-color: @light-accent-color;

--- a/less/variables.less
+++ b/less/variables.less
@@ -24,3 +24,4 @@
 @tagcloud-light-color: @light-tagcloud-light-color;
 @tagcloud-dark-color: @light-tagcloud-dark-color;
 @accent-color: @light-accent-color;
+@catalog-active-bg: @light-catalog-active-bg;


### PR DESCRIPTION
## 功能描述

为京吹学报添加完整的深色模式支持，提升夜间阅读体验。

## 主要特性

✨ **深色模式样式**
- 新增深色模式样式文件 (`less/dark-mode.less`, `css/dark-mode.css`)
- 完整适配所有页面元素的深色主题
- 精心设计的配色方案，保证可读性

🌙 **主题切换**
- 在导航栏添加主题切换按钮（月亮/太阳图标）
- 用户可一键切换亮色/深色模式
- 使用 localStorage 保存用户主题偏好

⚡ **优化体验**
- 实现无闪烁加载机制（页面加载时直接应用保存的主题）
- 平滑的主题切换动画
- 自动检测系统主题偏好（首次访问）

## 修改文件

- `Gruntfile.js` - 更新构建配置以支持编译深色模式样式
- `_includes/head.html` - 添加主题加载脚本（防止闪烁）
- `_includes/nav.html` - 添加主题切换按钮
- `css/dark-mode.css` - 编译后的深色模式样式
- `less/dark-mode.less` - 深色模式 LESS 源文件
- `less/hux-blog.less` - 更新主样式文件

## 测试方法

1. 访问网站首页
2. 在导航栏右上角找到主题切换按钮（月亮/太阳图标）
3. 点击按钮切换主题
4. 刷新页面，验证主题偏好是否被保存
5. 在不同页面（文章、标签、关于等）测试深色模式显示效果

## 浏览器兼容性

- Chrome/Edge 76+
- Firefox 67+
- Safari 12.1+
- 其他现代浏览器

## 相关 Issue

无

## 备注

- 深色模式不影响现有功能
- 用户可随时切换回亮色模式
- 主题偏好存储在浏览器本地，不涉及服务器

